### PR TITLE
Corrects checkout and cloning logic 

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -314,9 +314,9 @@ def run_benchmark_matrix(
 
         if not args.use_running_server:
             if args.valkey_path:
-                builder.terminate_server()
+                builder.terminate_valkey()
             else:
-                builder.cleanup_terminate()
+                builder.terminate_and_clean_valkey()
 
 
 # ---------- Entry point ------------------------------------------------------

--- a/benchmark.py
+++ b/benchmark.py
@@ -255,8 +255,6 @@ def run_benchmark_matrix(
         parse_core_range(args.client_cpu_range)
         bench_core_range = args.client_cpu_range
 
-    cleanup_required = not args.valkey_path or not args.use_running_server
-
     valkey_dir = (
         Path(args.valkey_path) if args.valkey_path else Path(f"../valkey_{commit_id}")
     )
@@ -314,8 +312,11 @@ def run_benchmark_matrix(
         except Exception as exc:
             logging.warning(f"Failed to update completed_commits.json: {exc}")
 
-        if cleanup_required:
-            builder.cleanup_terminate()
+        if not args.use_running_server:
+            if args.valkey_path:
+                builder.terminate_server()
+            else:
+                builder.cleanup_terminate()
 
 
 # ---------- Entry point ------------------------------------------------------

--- a/valkey_build.py
+++ b/valkey_build.py
@@ -34,21 +34,21 @@ class ServerBuilder:
     def clone_and_checkout(self) -> None:
         # If valkey_path exists, assume it has all the commits we need and skip cloning
         if self.valkey_dir.exists() and (self.valkey_dir / ".git").exists():
-            logging.info(
-                f"Using existing Valkey repository at {self.valkey_dir} - skipping clone and checkout"
-            )
-            return
-
-        # Only clone if directory doesn't exist
-        logging.info(f"Cloning Valkey repo into {self.valkey_dir}...")
-        self._run(["git", "clone", self.repo_url, str(self.valkey_dir)])
+            logging.info(f"Using existing Valkey repository at {self.valkey_dir}")
+        else:
+            # Only clone if directory doesn't exist
+            logging.info(f"Cloning Valkey repo into {self.valkey_dir}...")
+            self._run(["git", "clone", self.repo_url, str(self.valkey_dir)])
 
         if self.commit_id == "HEAD":
             return
 
-        # Checkout specific commit
+        # Checkout the commit_id
         logging.info(f"Checking out commit: {self.commit_id}")
-        self._run(["git", "checkout", self.commit_id], cwd=self.valkey_dir)
+        try:
+            self._run(["git", "checkout", self.commit_id], cwd=self.valkey_dir)
+        except subprocess.CalledProcessError:
+            logging.warning(f"Failed to checkout {self.commit_id}")
 
     def build(self) -> None:
         self.clone_and_checkout()

--- a/valkey_build.py
+++ b/valkey_build.py
@@ -60,8 +60,8 @@ class ServerBuilder:
         else:
             self._run(["make", "-j"], cwd=self.valkey_dir)
 
-    def cleanup_terminate(self) -> None:
-        """Terminate all valkey processes and delete the cloned Valkey directory."""
+    def terminate_server(self) -> None:
+        """Terminate all valkey processes."""
         logging.info("Terminating any running Valkey server processes...")
         try:
             self._run(["pkill", "-f", "valkey-server"])
@@ -73,8 +73,11 @@ class ServerBuilder:
                 logging.warning(f"pkill failed with exit code {e.returncode}")
         except Exception as e:
             logging.warning(f"Failed to terminate Valkey processes: {e}")
-
         time.sleep(2)
+
+    def cleanup_terminate(self) -> None:
+        """Terminate all valkey processes and delete the cloned Valkey directory."""
+        self.terminate_server()
         if self.valkey_dir.exists():
             logging.info(f"Removing Valkey directory {self.valkey_dir}")
             shutil.rmtree(self.valkey_dir)

--- a/valkey_build.py
+++ b/valkey_build.py
@@ -60,7 +60,7 @@ class ServerBuilder:
         else:
             self._run(["make", "-j"], cwd=self.valkey_dir)
 
-    def terminate_server(self) -> None:
+    def terminate_valkey(self) -> None:
         """Terminate all valkey processes."""
         logging.info("Terminating any running Valkey server processes...")
         try:
@@ -75,9 +75,9 @@ class ServerBuilder:
             logging.warning(f"Failed to terminate Valkey processes: {e}")
         time.sleep(2)
 
-    def cleanup_terminate(self) -> None:
+    def terminate_and_clean_valkey(self) -> None:
         """Terminate all valkey processes and delete the cloned Valkey directory."""
-        self.terminate_server()
+        self.terminate_valkey()
         if self.valkey_dir.exists():
             logging.info(f"Removing Valkey directory {self.valkey_dir}")
             shutil.rmtree(self.valkey_dir)

--- a/valkey_server.py
+++ b/valkey_server.py
@@ -162,6 +162,7 @@ class ServerLauncher:
         logging.info("Setting up cluster configuration...")
         try:
             with self._client_context(tls_mode) as client:
+                client.execute_command("CLUSTER", "RESET", "HARD")
                 client.execute_command("CLUSTER", "ADDSLOTSRANGE", "0", "16383")
                 logging.info("Cluster configuration completed successfully.")
         except Exception as e:


### PR DESCRIPTION
This corrects checkout and cloning logic while benchmarking a PR and otherwise when we provide the valkey-path.

This also adds a `cluster reset hard` for cluster mode enabled as while running it id the cluster is already setup the cluster setup would fail. 