### PR TITLE
Adds custom server configs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,33 @@ Create benchmark configurations in JSON format. Each object represents a single 
     "warmup": 10,
     "io-threads": [1, 4, 8],
     "server_cpu_range": "0-1",
-    "client_cpu_range": "2-3"
+    "client_cpu_range": "2-3",
+    "custom-server-configs": {
+      "maxmemory": "4gb",
+      "timeout": "300"
+    }
   }
 ]
+```
+
+#### Custom Server Configs Examples
+
+Add server configs the benchmark does not manage (e.g. memory limits, timeouts):
+```json
+"custom-server-configs": {
+  "maxmemory": "4gb",
+  "timeout": "300",
+  "maxclients": "10000"
+}
+```
+
+Combine with a baseline `.conf` file:
+```json
+"custom-server-config-file": "/etc/valkey/baseline.conf",
+"custom-server-configs": {
+  "hz": "100",
+  "tcp-keepalive": "60"
+}
 ````
 
 ### Configuration Parameters
@@ -274,6 +298,18 @@ Create benchmark configurations in JSON format. Each object represents a single 
 | `io-threads`       | Number of I/O threads for server                               | Integer             | Yes             |
 | `server_cpu_range` | CPU cores for server (e.g. "0-3", "0,2,4", or "144-191,48-95") | String              | No              |
 | `client_cpu_range` | CPU cores for client (e.g. "4-7", "1,3,5", or "0-3,8-11")      | String              | No              |
+| `custom-server-configs` | Additional server configuration options the benchmark does not manage (e.g. `{"maxmemory": "4gb", "timeout": "300"}`). | Object (key-value pairs) | No |
+| `custom-server-config-file` | Path to a Valkey-format `.conf` file passed positionally to `valkey-server`. Used as a baseline configuration. | String (path) | No |
+
+**Note on `custom-server-configs`**: This field lets you pass *additional* configuration options to the Valkey server at startup — settings the benchmark itself does not manage (e.g. `maxmemory`, `timeout`, `maxclients`, `tcp-keepalive`, `hz`).
+
+**Precedence**: Configs are applied in this order on the `valkey-server` command line:
+
+1. `custom-server-config-file` (positional, parsed first — lowest priority)
+2. `custom-server-configs` (`--key value` flags)
+3. Benchmark-managed defaults (`--key value` flags — highest priority via Valkey's last-wins semantics)
+
+This means harness-critical settings (`port`, `daemonize`, `logfile`, `cluster-*`, etc.) always take effect regardless of what the user supplies. Setting them in `custom-server-configs` is allowed but has no effect.
 
 When `warmup` is provided for read commands, the benchmark performs three stages:
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -53,6 +53,8 @@ OPTIONAL_CONF_KEYS = [
     "query_generation",
     "port",
     "module_startup_args",
+    "custom-server-configs",
+    "custom-server-config-file",
 ]
 
 
@@ -331,6 +333,22 @@ def validate_config(cfg: dict) -> None:
     if "port" in cfg:
         if not isinstance(cfg["port"], int) or cfg["port"] <= 0 or cfg["port"] > 65535:
             raise ValueError("'port' must be between 1 and 65535")
+    if "custom-server-configs" in cfg:
+        if not isinstance(cfg["custom-server-configs"], dict):
+            raise ValueError("'custom-server-configs' must be a dictionary")
+        for key, value in cfg["custom-server-configs"].items():
+            if not isinstance(key, str):
+                raise ValueError(
+                    f"'custom-server-configs' keys must be strings, got: {type(key)}"
+                )
+            # Note: bool is a subclass of int in Python, so check bool first.
+            if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+                raise ValueError(
+                    f"'custom-server-configs' values must be strings or numbers, got: {type(value)}"
+                )
+    if "custom-server-config-file" in cfg:
+        if not isinstance(cfg["custom-server-config-file"], str):
+            raise ValueError("'custom-server-config-file' must be a string path")
 
     if "cluster_mode" in cfg and not isinstance(cfg["cluster_mode"], list):
         cfg["cluster_mode"] = parse_bool(cfg["cluster_mode"])

--- a/tests/test_benchmark_config.py
+++ b/tests/test_benchmark_config.py
@@ -409,3 +409,70 @@ class TestGetActivePorts:
     def test_cluster_mode_without_cluster_ports_falls_back(self):
         cfg = {"cluster_mode": True, "port": 6380}
         assert _get_active_ports(cfg) == [6380]
+
+
+# ---------------------------------------------------------------------------
+# validate_config — custom-server-configs
+# ---------------------------------------------------------------------------
+
+
+class TestCustomServerConfigsValidation:
+    """Tests for custom-server-configs validation in validate_config."""
+
+    def test_valid_dict_with_str_int_float(self, minimal_valid_config):
+        minimal_valid_config["custom-server-configs"] = {
+            "maxmemory": "4gb",
+            "timeout": 300,
+            "tcp-keepalive": 60.0,
+        }
+        validate_config(minimal_valid_config)  # should not raise
+
+    def test_missing_key_is_fine(self, minimal_valid_config):
+        assert "custom-server-configs" not in minimal_valid_config
+        validate_config(minimal_valid_config)  # should not raise
+
+    def test_empty_dict_accepted(self, minimal_valid_config):
+        minimal_valid_config["custom-server-configs"] = {}
+        validate_config(minimal_valid_config)  # should not raise
+
+    @pytest.mark.parametrize("bad_value", ["a string", ["a", "list"], 42, None])
+    def test_reject_non_dict(self, minimal_valid_config, bad_value):
+        minimal_valid_config["custom-server-configs"] = bad_value
+        with pytest.raises(ValueError, match="must be a dictionary"):
+            validate_config(minimal_valid_config)
+
+    @pytest.mark.parametrize("bad_key", [1, None])
+    def test_reject_non_string_key(self, minimal_valid_config, bad_key):
+        minimal_valid_config["custom-server-configs"] = {bad_key: "v"}
+        with pytest.raises(ValueError, match="keys must be strings"):
+            validate_config(minimal_valid_config)
+
+    @pytest.mark.parametrize("bad_value", [True, False])
+    def test_reject_bool_value(self, minimal_valid_config, bad_value):
+        minimal_valid_config["custom-server-configs"] = {"k": bad_value}
+        with pytest.raises(ValueError, match="values must be strings or numbers"):
+            validate_config(minimal_valid_config)
+
+    @pytest.mark.parametrize("bad_value", [[1, 2], {"nested": 1}, None])
+    def test_reject_non_scalar_value(self, minimal_valid_config, bad_value):
+        minimal_valid_config["custom-server-configs"] = {"k": bad_value}
+        with pytest.raises(ValueError, match="values must be strings or numbers"):
+            validate_config(minimal_valid_config)
+
+
+class TestCustomServerConfigFileValidation:
+    """Tests for custom-server-config-file validation in validate_config."""
+
+    def test_valid_string_path(self, minimal_valid_config):
+        minimal_valid_config["custom-server-config-file"] = "/etc/valkey/extra.conf"
+        validate_config(minimal_valid_config)  # should not raise
+
+    def test_missing_key_is_fine(self, minimal_valid_config):
+        assert "custom-server-config-file" not in minimal_valid_config
+        validate_config(minimal_valid_config)  # should not raise
+
+    @pytest.mark.parametrize("bad_value", [42, ["/path"], {"path": "x"}, None, True])
+    def test_reject_non_string(self, minimal_valid_config, bad_value):
+        minimal_valid_config["custom-server-config-file"] = bad_value
+        with pytest.raises(ValueError, match="must be a string path"):
+            validate_config(minimal_valid_config)

--- a/tests/test_custom_server_configs.py
+++ b/tests/test_custom_server_configs.py
@@ -1,0 +1,160 @@
+"""Unit tests for custom-server-configs in ServerLauncher._build_server_command."""
+
+import pytest
+
+from valkey_server import ServerLauncher
+
+
+@pytest.fixture
+def launcher():
+    """Create a minimal ServerLauncher without triggering side effects."""
+    obj = ServerLauncher.__new__(ServerLauncher)
+    obj.cores = None
+    obj.target_ip = "127.0.0.1"
+    obj.config = {}
+    return obj
+
+
+def _call_build(launcher, cluster_mode=False):
+    """Helper to call _build_server_command with sensible defaults."""
+    return launcher._build_server_command(
+        port=6379,
+        bind_ip=None,
+        cpu_range=None,
+        tls_mode=False,
+        cluster_mode=cluster_mode,
+        io_threads=None,
+        module_path=None,
+        log_file="/tmp/test.log",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _build_server_command — custom-server-configs
+# ---------------------------------------------------------------------------
+
+
+class TestBuildServerCommandNoCustomConfigs:
+    """WHEN no custom-server-configs are set, cmd has no extra flags."""
+
+    def test_empty_config(self, launcher):
+        cmd = _call_build(launcher)
+        # The last config pair should be --save ''
+        assert cmd[-2:] == ["--save", "''"]
+
+    def test_config_without_custom_key(self, launcher):
+        launcher.config = {"some_other_key": "value"}
+        cmd = _call_build(launcher)
+        assert cmd[-2:] == ["--save", "''"]
+
+
+class TestBuildServerCommandCustomConfigsAppended:
+    """WHEN custom-server-configs are set, they appear in cmd before defaults."""
+
+    def test_configs_appear_in_cmd(self, launcher):
+        launcher.config = {
+            "custom-server-configs": {"maxmemory": "4gb", "timeout": 300}
+        }
+        cmd = _call_build(launcher)
+        assert "--maxmemory" in cmd
+        assert "4gb" in cmd
+        assert "--timeout" in cmd
+        assert "300" in cmd
+
+    def test_configs_appear_BEFORE_benchmark_defaults(self, launcher):
+        """Custom configs must come before the defaults block so last-wins
+        semantics give defaults precedence."""
+        launcher.config = {"custom-server-configs": {"maxmemory": "4gb"}}
+        cmd = _call_build(launcher)
+        save_idx = cmd.index("--save")
+        maxmemory_idx = cmd.index("--maxmemory")
+        assert maxmemory_idx < save_idx, (
+            f"custom config should come before defaults; got "
+            f"--maxmemory at {maxmemory_idx}, --save at {save_idx}"
+        )
+
+
+class TestBuildServerCommandClusterMode:
+    """Custom configs also apply in cluster mode."""
+
+    def test_cluster_mode_applies_custom_configs(self, launcher):
+        launcher.config = {"custom-server-configs": {"hz": "100"}}
+        cmd = _call_build(launcher, cluster_mode=True)
+        assert "--hz" in cmd
+        assert "100" in cmd
+
+
+class TestBuildServerCommandNumericStringification:
+    """Numeric values are stringified in the command."""
+
+    def test_int_value_stringified(self, launcher):
+        launcher.config = {"custom-server-configs": {"timeout": 300}}
+        cmd = _call_build(launcher)
+        idx = cmd.index("--timeout")
+        assert cmd[idx + 1] == "300"
+
+    def test_float_value_stringified(self, launcher):
+        launcher.config = {"custom-server-configs": {"hz": 10.5}}
+        cmd = _call_build(launcher)
+        idx = cmd.index("--hz")
+        assert cmd[idx + 1] == "10.5"
+
+
+class TestBuildServerCommandDefenseInDepth:
+    """Even if a reserved key bypassed validation, harness defaults still win
+    via valkey CLI last-wins semantics (defaults come after custom configs)."""
+
+    def test_benchmark_defaults_win_on_collision(self, launcher):
+        # Bypass validation by setting config directly on launcher.
+        launcher.config = {"custom-server-configs": {"maxmemory-policy": "noeviction"}}
+        cmd = _call_build(launcher)
+        # Both should be present; the LAST occurrence is what valkey honors.
+        assert cmd.count("--maxmemory-policy") == 2
+        last_idx = len(cmd) - 1 - cmd[::-1].index("--maxmemory-policy")
+        assert (
+            cmd[last_idx + 1] == "allkeys-lru"
+        ), "benchmark default must come last (and therefore win)"
+
+
+# ---------------------------------------------------------------------------
+# _build_server_command — custom-server-config-file
+# ---------------------------------------------------------------------------
+
+
+class TestBuildServerCommandCustomConfigFile:
+    """Optional positional config file passed right after the binary."""
+
+    def test_no_conf_file_means_no_positional(self, launcher):
+        """Without conf file, no positional arg between binary and first --flag."""
+        cmd = _call_build(launcher)
+        binary_idx = next(i for i, x in enumerate(cmd) if x.endswith("valkey-server"))
+        assert cmd[binary_idx + 1].startswith("--")
+
+    def test_conf_file_appears_right_after_binary(self, launcher):
+        """Conf file must be the first positional arg after valkey-server."""
+        launcher.config = {"custom-server-config-file": "/etc/valkey/extra.conf"}
+        cmd = _call_build(launcher)
+        binary_idx = next(i for i, x in enumerate(cmd) if x.endswith("valkey-server"))
+        assert cmd[binary_idx + 1] == "/etc/valkey/extra.conf"
+        # The next token must start with "--" (flags come after)
+        assert cmd[binary_idx + 2].startswith("--")
+
+    def test_conf_file_precedes_custom_configs_and_defaults(self, launcher):
+        """Order: conf file (lowest) → custom configs → benchmark defaults."""
+        launcher.config = {
+            "custom-server-config-file": "/etc/valkey/base.conf",
+            "custom-server-configs": {"maxmemory": "8gb"},
+        }
+        cmd = _call_build(launcher)
+        conf_idx = cmd.index("/etc/valkey/base.conf")
+        maxmem_idx = cmd.index("--maxmemory")
+        save_idx = cmd.index("--save")
+        assert conf_idx < maxmem_idx < save_idx
+
+    def test_only_conf_file_no_inline(self, launcher):
+        """Conf file alone works; cmd has no extra --flags from inline."""
+        launcher.config = {"custom-server-config-file": "/path/to/x.conf"}
+        cmd = _call_build(launcher)
+        assert "/path/to/x.conf" in cmd
+        # Last config pair should still be --save '' (no inline appended)
+        assert cmd[-2:] == ["--save", "''"]

--- a/valkey_server.py
+++ b/valkey_server.py
@@ -136,6 +136,16 @@ class ServerLauncher:
 
         cmd.append(VALKEY_SERVER)
 
+        # Optional positional config file (must come right after the binary,
+        # before any --flag args). Subsequent --flag values override file values.
+        custom_conf_file = (
+            (self.config or {}).get("custom-server-config-file")
+            if hasattr(self, "config")
+            else None
+        )
+        if custom_conf_file:
+            cmd.append(custom_conf_file)
+
         # Port and TLS configuration
         if tls_mode:
             cmd += ["--tls-port", str(port), "--port", "0"]
@@ -169,7 +179,20 @@ class ServerLauncher:
             if not bind_ip:
                 cmd += ["--cluster-announce-ip", self.target_ip]
 
-        # Common server configuration
+        # Apply custom-server-configs from benchmark config. These are added
+        # BEFORE the benchmark defaults block so that, by valkey CLI last-wins
+        # semantics, the harness's defaults always take precedence over any
+        # user-supplied value for the same key.
+        custom_configs = (
+            (self.config or {}).get("custom-server-configs")
+            if hasattr(self, "config")
+            else None
+        )
+        if custom_configs:
+            for key, value in custom_configs.items():
+                cmd += [f"--{key}", str(value)]
+
+        # Common server configuration (benchmark defaults — always win).
         cmd += [
             "--cluster-enabled",
             "yes" if cluster_mode else "no",


### PR DESCRIPTION
## Summary

Adds support for passing arbitrary configuration to `valkey-server` at startup via two new optional fields in `benchmark-configs.json`:

| Field | Purpose |
|---|---|
| `custom-server-configs` | Inline `{key: value}` map of `--key value` flags to pass through |
| `custom-server-config-file` | Path to a Valkey-format `.conf` file passed positionally |

Useful for setting workload-relevant tunables like `maxmemory`, `timeout`, `maxclients`, `tcp-keepalive`, `hz`, etc. without touching the harness.

### Example

```json
{
  "duration": 120,
  "commands": ["SET", "GET"],
  "cluster_mode": false,
  "tls_mode": false,
  "custom-server-config-file": "/etc/valkey/baseline.conf",
  "custom-server-configs": {
    "maxmemory": "4gb",
    "timeout": 300
  }
}
```

### Precedence

Configs are applied in this order on the `valkey-server` command line:

1. `custom-server-config-file` (positional, parsed first; lowest priority)
2. `custom-server-configs` (`--key value` flags)
3. Benchmark-managed defaults (highest priority via Valkey's last-wins semantics)

This means harness-critical settings (`port`, `daemonize`, `logfile`, `cluster-*`, etc.) always take effect regardless of what the user supplies.

### Validation

`validate_config` enforces:
- `custom-server-configs` is a dict
- Keys are strings
- Values are strings, ints, or floats. Booleans rejected because Python's `str(True)` does not produce a valid Valkey config value.
- `custom-server-config-file` is a string path

### Tests

- 20 validation tests in `tests/test_benchmark_config.py`
- 14 server-command tests in `tests/test_custom_server_configs.py` covering single-node, cluster mode, ordering, and defense-in-depth (benchmark defaults win on collision)
