### PR TITLE
Pass --cluster to valkey-benchmark in cluster mode

### DIFF
--- a/tests/test_benchmark_command.py
+++ b/tests/test_benchmark_command.py
@@ -57,6 +57,41 @@ class TestBuildBenchmarkCommandSimpleFormat:
         )
         assert "taskset" not in cmd
 
+    def test_simple_format_includes_cluster_flag_in_cluster_mode(
+        self, minimal_client_runner, base_cmd_params
+    ):
+        """Simple format commands include --cluster when cluster mode is enabled."""
+        minimal_client_runner.cluster_mode = True
+
+        cmd = minimal_client_runner._build_benchmark_command(
+            command="SET", **base_cmd_params
+        )
+
+        assert "--cluster" in cmd
+
+    def test_simple_format_omits_cluster_flag_when_cluster_mode_disabled(
+        self, minimal_client_runner, base_cmd_params
+    ):
+        """Simple format commands should not include --cluster outside cluster mode."""
+        cmd = minimal_client_runner._build_benchmark_command(
+            command="SET", **base_cmd_params
+        )
+
+        assert "--cluster" not in cmd
+
+    def test_simple_format_includes_cluster_flag_without_cluster_nodes_config(
+        self, minimal_client_runner, base_cmd_params
+    ):
+        """Issue #27 regression: cluster mode should not depend on cluster_nodes metadata."""
+        minimal_client_runner.cluster_mode = True
+        minimal_client_runner.config.pop("cluster_nodes", None)
+
+        cmd = minimal_client_runner._build_benchmark_command(
+            command="SET", **base_cmd_params
+        )
+
+        assert "--cluster" in cmd
+
 
 class TestBuildBenchmarkCommandTLS:
     """Test TLS mode includes TLS flags."""
@@ -143,3 +178,68 @@ class TestBuildBenchmarkCommandDuration:
         assert "-n" in cmd
         assert cmd[cmd.index("-n") + 1] == "5000"
         assert "--duration" not in cmd
+
+
+class TestBuildBenchmarkCommandScenarios:
+    """Test scenario-based command construction."""
+
+    def test_single_node_scenario_includes_cluster_flag_in_cluster_mode(
+        self, minimal_client_runner
+    ):
+        """Scenario commands include --cluster for single-node execution in cluster mode."""
+        minimal_client_runner.cluster_mode = True
+
+        cmd = minimal_client_runner._build_benchmark_command(
+            scenario={
+                "command": "SET foo bar",
+                "type": "write",
+                "cluster_execution": "single",
+            }
+        )
+
+        assert "--cluster" in cmd
+
+    def test_single_node_scenario_includes_cluster_flag_without_cluster_nodes_config(
+        self, minimal_client_runner
+    ):
+        """Scenario cluster routing should not depend on cluster_nodes metadata."""
+        minimal_client_runner.cluster_mode = True
+        minimal_client_runner.config.pop("cluster_nodes", None)
+
+        cmd = minimal_client_runner._build_benchmark_command(
+            scenario={
+                "command": "SET foo bar",
+                "type": "write",
+                "cluster_execution": "single",
+            }
+        )
+
+        assert "--cluster" in cmd
+
+    def test_parallel_scenario_omits_cluster_flag(self, minimal_client_runner):
+        """Parallel cluster execution should not pass --cluster to a single command."""
+        minimal_client_runner.cluster_mode = True
+
+        cmd = minimal_client_runner._build_benchmark_command(
+            scenario={
+                "command": "SET foo bar",
+                "type": "write",
+                "cluster_execution": "parallel",
+            }
+        )
+
+        assert "--cluster" not in cmd
+
+    def test_single_node_scenario_omits_cluster_flag_when_cluster_mode_disabled(
+        self, minimal_client_runner
+    ):
+        """Scenario commands should not include --cluster outside cluster mode."""
+        cmd = minimal_client_runner._build_benchmark_command(
+            scenario={
+                "command": "SET foo bar",
+                "type": "write",
+                "cluster_execution": "single",
+            }
+        )
+
+        assert "--cluster" not in cmd

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -229,6 +229,14 @@ class ClientRunner:
             return self.config["cluster_ports"]
         return [self.config.get("port", 6379)]
 
+    def _should_add_cluster_flag(self, scenario: Optional[dict] = None) -> bool:
+        """Return whether the valkey-benchmark command should include --cluster."""
+        if not self.cluster_mode:
+            return False
+        if scenario is None:
+            return True
+        return scenario.get("cluster_execution", "single") == "single"
+
     def _flush_database(self) -> None:
         """Flush all data from the database before benchmark runs."""
         logging.info(
@@ -649,9 +657,8 @@ class ClientRunner:
             if scenario.get("sequential", False):
                 cmd += ["--sequential"]
 
-            if scenario.get("cluster_execution") == "single":
-                if self.cluster_mode and self.config.get("cluster_nodes"):
-                    cmd += ["--cluster"]
+            if self._should_add_cluster_flag(scenario):
+                cmd += ["--cluster"]
 
             # Seed: Default ON unless explicitly disabled with "seed": false
             if (
@@ -685,6 +692,9 @@ class ClientRunner:
 
             if sequential:
                 cmd += ["--sequential"]
+
+            if self._should_add_cluster_flag():
+                cmd += ["--cluster"]
 
             # Unified seed logic: Default ON unless config disables
             if self.config.get("seed") is not False:


### PR DESCRIPTION
## Summary

This fixes client benchmark runs against cluster deployments by passing `--cluster` to `valkey-benchmark` whenever `cluster_mode` is enabled for single-command execution.

## Root Cause

The command builder only appended `--cluster` in a narrow scenario-based path and also depended on optional `cluster_nodes` config being present. As a result, standard command benchmarks could run with `cluster_mode: true` but still invoke `valkey-benchmark` without `--cluster`, which caused `MOVED` errors from the server.

## Changes

- add a shared helper to decide when `--cluster` should be included
- append `--cluster` for simple command benchmarks whenever `cluster_mode` is enabled
- keep scenario-based behavior aligned by adding `--cluster` for `cluster_execution: "single"` and omitting it for parallel execution
- add regression tests covering simple commands, scenario execution modes, and the missing-`cluster_nodes` edge case from issue #27

## Impact

Cluster-mode benchmark runs now invoke `valkey-benchmark` with the correct routing behavior, so client-only runs against an existing cluster no longer fail due to redirected commands.

## Validation

- `pytest tests/test_benchmark_command.py`
- `pytest tests/test_client_runner_logic.py`

Closes #27
