### PR TITLE
Fix benchmark comparison metric handling and significance logic

### DIFF
--- a/tests/test_compare_benchmark.py
+++ b/tests/test_compare_benchmark.py
@@ -18,10 +18,12 @@ from utils.compare_benchmark_results import (
     create_config_signature,
     create_config_sort_key,
     summarize_benchmark_results,
+    create_comparison_table_data,
     _format_with_sig_figs,
     _format_stats_only,
     _format_percent_change,
     _extract_common_and_unique_config,
+    _get_significance_indicator,
     CONFIDENCE_PERCENT,
 )
 
@@ -426,10 +428,10 @@ class TestSummarizeBenchmarkResults:
         result = summarize_benchmark_results([])
         assert result == {
             "rps": 0.0,
-            "latency_avg_ms": 0.0,
-            "latency_p50_ms": 0.0,
-            "latency_p95_ms": 0.0,
-            "latency_p99_ms": 0.0,
+            "avg_latency_ms": 0.0,
+            "p50_latency_ms": 0.0,
+            "p95_latency_ms": 0.0,
+            "p99_latency_ms": 0.0,
         }
 
     def test_single_item_returns_its_values(self):
@@ -442,10 +444,10 @@ class TestSummarizeBenchmarkResults:
         }
         result = summarize_benchmark_results([item])
         assert result["rps"] == 100000.0
-        assert result["latency_avg_ms"] == 1.0
-        assert result["latency_p50_ms"] == 0.8
-        assert result["latency_p95_ms"] == 1.5
-        assert result["latency_p99_ms"] == 2.0
+        assert result["avg_latency_ms"] == 1.0
+        assert result["p50_latency_ms"] == 0.8
+        assert result["p95_latency_ms"] == 1.5
+        assert result["p99_latency_ms"] == 2.0
 
     def test_multiple_items_returns_means(self):
         items = [
@@ -466,25 +468,10 @@ class TestSummarizeBenchmarkResults:
         ]
         result = summarize_benchmark_results(items)
         assert result["rps"] == pytest.approx(150000.0)
-        assert result["latency_avg_ms"] == pytest.approx(0.75)
-        assert result["latency_p50_ms"] == pytest.approx(0.6)
-        assert result["latency_p95_ms"] == pytest.approx(1.15)
-        assert result["latency_p99_ms"] == pytest.approx(1.5)
-
-    def test_new_field_naming_convention(self):
-        item = {
-            "rps": 100000.0,
-            "latency_avg_ms": 1.0,
-            "latency_p50_ms": 0.8,
-            "latency_p95_ms": 1.5,
-            "latency_p99_ms": 2.0,
-        }
-        result = summarize_benchmark_results([item])
-        assert result["rps"] == 100000.0
-        assert result["latency_avg_ms"] == 1.0
-        assert result["latency_p50_ms"] == 0.8
-        assert result["latency_p95_ms"] == 1.5
-        assert result["latency_p99_ms"] == 2.0
+        assert result["avg_latency_ms"] == pytest.approx(0.75)
+        assert result["p50_latency_ms"] == pytest.approx(0.6)
+        assert result["p95_latency_ms"] == pytest.approx(1.15)
+        assert result["p99_latency_ms"] == pytest.approx(1.5)
 
 
 # --- _format_with_sig_figs ---
@@ -730,3 +717,106 @@ class TestExtractCommonAndUniqueConfig:
         assert common == {}
         assert groups[0]["unique_config"] == {"data_size": 16}
         assert groups[1]["unique_config"] == {"data_size": 64}
+
+
+# --- TestComparisonPipeline ---
+
+
+class TestComparisonPipeline:
+    """End-to-end tests for the comparison pipeline."""
+
+    def _make_run(
+        self,
+        rps,
+        avg,
+        p50,
+        p95,
+        p99,
+        command="GET",
+        pipeline=1,
+        io_threads=1,
+        commit="abc123",
+    ):
+        return {
+            "command": command,
+            "pipeline": pipeline,
+            "io_threads": io_threads,
+            "data_size": 32,
+            "clients": 50,
+            "rps": rps,
+            "avg_latency_ms": avg,
+            "p50_latency_ms": p50,
+            "p95_latency_ms": p95,
+            "p99_latency_ms": p99,
+            "commit": commit,
+        }
+
+    def test_end_to_end_percentage_change(self):
+        baseline_data = [
+            self._make_run(98000, 1.02, 0.81, 1.48, 1.95, commit="base111"),
+            self._make_run(102000, 0.98, 0.79, 1.52, 2.05, commit="base111"),
+            self._make_run(100000, 1.00, 0.80, 1.50, 2.00, commit="base111"),
+        ]
+        new_data = [
+            self._make_run(118000, 0.82, 0.61, 1.18, 1.58, commit="new2222"),
+            self._make_run(122000, 0.78, 0.59, 1.22, 1.62, commit="new2222"),
+            self._make_run(120000, 0.80, 0.60, 1.20, 1.60, commit="new2222"),
+        ]
+
+        baseline_averaged = average_multiple_runs(baseline_data)
+        new_averaged = average_multiple_runs(new_data)
+
+        config_groups, baseline_ver, new_ver, _, _ = create_comparison_table_data(
+            baseline_averaged, new_averaged
+        )
+
+        assert len(config_groups) == 1
+        rows = config_groups[0]["table_rows"]
+
+        # RPS: mean 100000 -> 120000 = +20%
+        rps_row = next(r for r in rows if r["metric"] == "rps")
+        assert rps_row["baseline_value"] == pytest.approx(100000.0)
+        assert rps_row["new_value"] == pytest.approx(120000.0)
+        assert rps_row["change"] == pytest.approx(20.0)
+
+        # avg latency: mean 1.0 -> 0.8 = -20%
+        avg_row = next(r for r in rows if r["metric"] == "avg_latency")
+        assert avg_row["baseline_value"] == pytest.approx(1.0)
+        assert avg_row["new_value"] == pytest.approx(0.8)
+        assert avg_row["change"] == pytest.approx(-20.0)
+
+        # p99 latency: mean 2.0 -> 1.6 = -20%
+        p99_row = next(r for r in rows if r["metric"] == "p99_latency")
+        assert p99_row["baseline_value"] == pytest.approx(2.0)
+        assert p99_row["new_value"] == pytest.approx(1.6)
+        assert p99_row["change"] == pytest.approx(-20.0)
+
+        # Verify version extraction worked
+        assert baseline_ver == "base111"
+        assert new_ver == "new2222"
+
+    def test_significance_direction_by_metric_type(self):
+        # Latency decrease = improvement
+        assert (
+            _get_significance_indicator(5, 5, 1.8, 2.2, 1.0, 1.4, -30.0, "avg_latency")
+            == "✅"
+        )
+        # Latency increase = regression
+        assert (
+            _get_significance_indicator(5, 5, 1.0, 1.4, 1.8, 2.2, 50.0, "p99_latency")
+            == "❌"
+        )
+        # RPS increase = improvement
+        assert (
+            _get_significance_indicator(
+                5, 5, 90000.0, 100000.0, 110000.0, 120000.0, 20.0, "rps"
+            )
+            == "✅"
+        )
+        # RPS decrease = regression
+        assert (
+            _get_significance_indicator(
+                5, 5, 110000.0, 120000.0, 90000.0, 100000.0, -15.0, "rps"
+            )
+            == "❌"
+        )

--- a/utils/compare_benchmark_results.py
+++ b/utils/compare_benchmark_results.py
@@ -924,7 +924,7 @@ def _generate_summary(
                 row.get("new_ci_lower", 0.0),
                 row.get("new_ci_upper", 0.0),
                 row["change"],
-                row.get("metric", ""),
+                row["metric"],
             )
 
             test_label = f"{row['command']} {row['metric']} pipe={row['pipeline']} threads={row['io_threads']}"
@@ -1086,7 +1086,7 @@ def format_comparison_report(
                 row.get("new_ci_lower", 0.0),
                 row.get("new_ci_upper", 0.0),
                 row["change"],
-                row.get("metric", ""),
+                row["metric"],
             )
 
             # Format % change with uncertainty
@@ -1169,7 +1169,7 @@ def _get_significance_indicator(
     new_ci_lower: float,
     new_ci_upper: float,
     change_percent: float,
-    metric: str = "",
+    metric: str,
 ) -> str:
     """
     Determine significance indicator based on CI overlap.

--- a/utils/compare_benchmark_results.py
+++ b/utils/compare_benchmark_results.py
@@ -231,10 +231,6 @@ def discover_config_keys(data: List[Dict[str, Any]]) -> List[str]:
         "p95_latency_ms",
         "p99_latency_ms",
         "max_latency_ms",
-        "latency_avg_ms",
-        "latency_p50_ms",
-        "latency_p95_ms",
-        "latency_p99_ms",
         # Standard deviation fields
         "rps_stdev",
         "avg_latency_ms_stdev",
@@ -308,49 +304,28 @@ def group_by_command(items: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, An
 
 
 def summarize_benchmark_results(data_items: List[Dict[str, Any]]) -> Dict[str, float]:
-    """
-    Calculate summary statistics for a group of benchmark results.
-
-    Handles both old and new field naming conventions for latency metrics.
-    """
+    """Calculate summary statistics for a group of benchmark results."""
     if not data_items:
         return {
             "rps": 0.0,
-            "latency_avg_ms": 0.0,
-            "latency_p50_ms": 0.0,
-            "latency_p95_ms": 0.0,
-            "latency_p99_ms": 0.0,
+            "avg_latency_ms": 0.0,
+            "p50_latency_ms": 0.0,
+            "p95_latency_ms": 0.0,
+            "p99_latency_ms": 0.0,
         }
 
-    # Extract values with fallback for different field names
     rps_values = [item.get("rps", 0.0) for item in data_items]
-
-    avg_latency_values = [
-        item.get("avg_latency_ms", item.get("latency_avg_ms", 0.0))
-        for item in data_items
-    ]
-
-    p50_latency_values = [
-        item.get("p50_latency_ms", item.get("latency_p50_ms", 0.0))
-        for item in data_items
-    ]
-
-    p95_latency_values = [
-        item.get("p95_latency_ms", item.get("latency_p95_ms", 0.0))
-        for item in data_items
-    ]
-
-    p99_latency_values = [
-        item.get("p99_latency_ms", item.get("latency_p99_ms", 0.0))
-        for item in data_items
-    ]
+    avg_latency_values = [item.get("avg_latency_ms", 0.0) for item in data_items]
+    p50_latency_values = [item.get("p50_latency_ms", 0.0) for item in data_items]
+    p95_latency_values = [item.get("p95_latency_ms", 0.0) for item in data_items]
+    p99_latency_values = [item.get("p99_latency_ms", 0.0) for item in data_items]
 
     return {
         "rps": calculate_mean(rps_values),
-        "latency_avg_ms": calculate_mean(avg_latency_values),
-        "latency_p50_ms": calculate_mean(p50_latency_values),
-        "latency_p95_ms": calculate_mean(p95_latency_values),
-        "latency_p99_ms": calculate_mean(p99_latency_values),
+        "avg_latency_ms": calculate_mean(avg_latency_values),
+        "p50_latency_ms": calculate_mean(p50_latency_values),
+        "p95_latency_ms": calculate_mean(p95_latency_values),
+        "p99_latency_ms": calculate_mean(p99_latency_values),
     }
 
 
@@ -404,22 +379,10 @@ def average_multiple_runs(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             # Multiple runs: calculate averages and standard deviations
             metric_values = {
                 "rps": [run.get("rps", 0.0) for run in runs],
-                "avg_latency_ms": [
-                    run.get("avg_latency_ms", run.get("latency_avg_ms", 0.0))
-                    for run in runs
-                ],
-                "p50_latency_ms": [
-                    run.get("p50_latency_ms", run.get("latency_p50_ms", 0.0))
-                    for run in runs
-                ],
-                "p95_latency_ms": [
-                    run.get("p95_latency_ms", run.get("latency_p95_ms", 0.0))
-                    for run in runs
-                ],
-                "p99_latency_ms": [
-                    run.get("p99_latency_ms", run.get("latency_p99_ms", 0.0))
-                    for run in runs
-                ],
+                "avg_latency_ms": [run.get("avg_latency_ms", 0.0) for run in runs],
+                "p50_latency_ms": [run.get("p50_latency_ms", 0.0) for run in runs],
+                "p95_latency_ms": [run.get("p95_latency_ms", 0.0) for run in runs],
+                "p99_latency_ms": [run.get("p99_latency_ms", 0.0) for run in runs],
             }
 
             # Calculate means, standard deviations, coefficient of variation, and confidence intervals
@@ -611,10 +574,10 @@ def create_comparison_table_data(
     # Define available metrics with their display names
     available_metrics = [
         ("rps", "rps"),
-        ("latency_avg_ms", "avg_latency"),
-        ("latency_p50_ms", "p50_latency"),
-        ("latency_p95_ms", "p95_latency"),
-        ("latency_p99_ms", "p99_latency"),
+        ("avg_latency_ms", "avg_latency"),
+        ("p50_latency_ms", "p50_latency"),
+        ("p95_latency_ms", "p95_latency"),
+        ("p99_latency_ms", "p99_latency"),
     ]
 
     # Select metrics based on filter
@@ -622,10 +585,10 @@ def create_comparison_table_data(
         selected_metrics = [("rps", "rps")]
     elif metrics_filter == "latency":
         selected_metrics = [
-            ("latency_avg_ms", "avg_latency"),
-            ("latency_p50_ms", "p50_latency"),
-            ("latency_p95_ms", "p95_latency"),
-            ("latency_p99_ms", "p99_latency"),
+            ("avg_latency_ms", "avg_latency"),
+            ("p50_latency_ms", "p50_latency"),
+            ("p95_latency_ms", "p95_latency"),
+            ("p99_latency_ms", "p99_latency"),
         ]
     else:  # "all" or any other value
         selected_metrics = available_metrics
@@ -961,6 +924,7 @@ def _generate_summary(
                 row.get("new_ci_lower", 0.0),
                 row.get("new_ci_upper", 0.0),
                 row["change"],
+                row.get("metric", ""),
             )
 
             test_label = f"{row['command']} {row['metric']} pipe={row['pipeline']} threads={row['io_threads']}"
@@ -1122,6 +1086,7 @@ def format_comparison_report(
                 row.get("new_ci_lower", 0.0),
                 row.get("new_ci_upper", 0.0),
                 row["change"],
+                row.get("metric", ""),
             )
 
             # Format % change with uncertainty
@@ -1204,6 +1169,7 @@ def _get_significance_indicator(
     new_ci_lower: float,
     new_ci_upper: float,
     change_percent: float,
+    metric: str = "",
 ) -> str:
     """
     Determine significance indicator based on CI overlap.
@@ -1218,13 +1184,16 @@ def _get_significance_indicator(
     if baseline_run_count <= 1 or new_run_count <= 1:
         return "❔"
 
-    # Check CI overlap
-    # No overlap if new's lower bound > baseline's upper bound (improvement)
-    # or new's upper bound < baseline's lower bound (regression)
+    # For latency metrics, lower values are better (less delay)
+    # For throughput metrics (rps), higher values are better
+    lower_is_better = "latency" in metric
+
+    # No overlap: new's lower bound > baseline's upper bound means new value increased
     if new_ci_lower > baseline_ci_upper:
-        return "✅"  # Significant improvement
+        return "❌" if lower_is_better else "✅"
+    # No overlap: new's upper bound < baseline's lower bound means new value decreased
     elif new_ci_upper < baseline_ci_lower:
-        return "❌"  # Significant regression
+        return "✅" if lower_is_better else "❌"
     else:
         return "➖"  # CIs overlap, not significant
 
@@ -1575,16 +1544,10 @@ def _generate_single_variance_graph(
             new_values = []
 
             for run in baseline_runs:
-                value = run.get(
-                    metric, run.get(f'latency_{metric.split("_")[-1]}', 0.0)
-                )
-                baseline_values.append(value)
+                baseline_values.append(run.get(metric, 0.0))
 
             for run in new_runs:
-                value = run.get(
-                    metric, run.get(f'latency_{metric.split("_")[-1]}', 0.0)
-                )
-                new_values.append(value)
+                new_values.append(run.get(metric, 0.0))
 
             # Plot baseline runs
             if baseline_values:


### PR DESCRIPTION
Remove redundant latency_ prefix mapping that made the comparison pipeline fragile. All metrics now use canonical field names (avg_latency_ms, p50_latency_ms, etc.) consistently without fallbacks.

Fix _get_significance_indicator to correctly distinguish latency (lower-is-better) from throughput (higher-is-better) when determining if a change is an improvement or regression.

Add end-to-end pipeline tests covering both changes.