### PR TITLE
Add mixed workload scenario and fuzzy dataset transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,37 @@ Supported commands:
 "SET", "GET", "RPUSH", "LPUSH", "LPOP", "SADD", "SPOP", "HSET", "GET", "MGET", "LRANGE", "SPOP", "ZPOPMIN"
 ```
 
+### Scenario-based Configurations (`test_groups`)
+
+For module benchmarks (e.g. `valkey-search`) a scenario-based format is also supported.
+Instead of a cross-product of `commands x data_sizes x ...`, each scenario is an
+explicit test with its own `command`, `dataset`, `clients`, `duration`/`requests`,
+and `warmup`. Scenarios are grouped under `test_groups`. Sub-flags of the command
+can be expanded via `options` (e.g. `NOCONTENT`) into separate variants.
+
+Two scenario types worth calling out:
+
+- **`type: "write"` / `type: "read"`** — a single benchmark process against the
+  server. Reads may be `cluster_execution: "parallel"` to fan out one client per
+  cluster node.
+- **`type: "mixed"`** — spawns concurrent write **and** read processes in the same
+  test window. Each sub-scenario listed under `writes: [...]` and `reads: [...]`
+  becomes its own `valkey-benchmark` process on its own CPU range and produces
+  its own metric entry (`test_phase: mixed_write` / `mixed_read`). Options
+  declared on a mixed scenario are applied to every read sub-scenario, not to a
+  (non-existent) top-level command.
+
+Datasets consumed by scenarios can be generated ahead of time from a
+`dataset_generation` block in the same config, via `scripts/setup_datasets.py`.
+Supported CSV transforms include `wikipedia`, `inject`, `repeat`, `prefix_gen`,
+`proximity_phrase`, `expansion`, `fuzzy`, `numeric_range`, and `tag_list`. The
+`fuzzy` transform pairs with a `type: "fuzzy"` query generator so a query term
+matches variant 0 of its corresponding dataset row and `target_distance`-edit
+variants (insert/delete/substitute) match under fuzzy search.
+
+See `configs/module-test-arm.json` for a runnable example that includes a
+mixed workload and per-cluster-execution options.
+
 ## Results
 
 Benchmark results are stored in the `results/` directory, organized by commit ID:
@@ -804,6 +835,16 @@ The framework uses a **transform-based dataset generation system** that supports
 - `proximity_phrase`: Generate N-term phrases for proximity testing
   - Parameters: `term_count`, `combinations` (1=best case, 100=worst case), `repeats` (copies per pattern)
   - Supports CSV output (no Wikipedia needed)
+- `expansion`: Generate wildcard-expansion variants (term001_a, term001_aa, ...) grouped
+  as `expansion_count` × `docs_per_expansion` copies × `term_count` base terms
+- `fuzzy`: Generate misspelled variants for fuzzy-match tests
+  - Parameters: `variant_count`, `docs_per_variant`, `term_count`, `min_word_length`,
+    `max_word_length`, `target_distance`
+  - Variant 0 is the correctly-spelled base word (matches `type: "fuzzy"` queries);
+    variants ≥1 apply `target_distance` Levenshtein edits (insert/delete/substitute)
+- `numeric_range`: Random numeric value in `[min, max]` (for NUMERIC index tests)
+- `tag_list`: Pipe-separated random tags from a supplied list (for TAG index tests)
+
 
 **Compact Format (for field explosion):**
 ```json
@@ -829,6 +870,17 @@ The framework uses a **transform-based dataset generation system** that supports
 ```
 - Auto-generates query CSVs matching ingestion datasets
 - Supports type-based generation (extensible for future query types)
+
+Supported query types:
+- `proximity_phrase` — multi-column phrase terms matching a `proximity_phrase` transform
+- `prefix` / `suffix` — substring queries extracted from an existing source CSV
+- `expansion` — zero-padded base terms (e.g. `term001`) matching an `expansion` transform
+- `fuzzy` — deterministic base words matching variant 0 of a `fuzzy` transform, so
+  every query has known matches in the dataset (parameters: `min_word_length`,
+  `max_word_length`)
+- `tag_only` — rotates through a supplied `tags` list to produce category filters
+  for composed TAG queries
+
 
 ### FTS Test Groups
 

--- a/scripts/setup_datasets.py
+++ b/scripts/setup_datasets.py
@@ -3,6 +3,7 @@
 
 import argparse
 import csv
+import hashlib
 import json
 import logging
 import random
@@ -11,7 +12,21 @@ import sys
 import urllib.request
 import xml.etree.ElementTree as ET
 from pathlib import Path
+
 import numpy as np
+
+
+def _make_rng(filename: str) -> "np.random.Generator":
+    """Return a numpy Generator seeded deterministically from `filename`.
+
+    Two invocations against the same filename produce byte-identical output,
+    so vector datasets and query vectors are reproducible across machines.
+    Different filenames get different content (avoids accidentally emitting
+    the same random values for e.g. hybrid data and queries).
+    """
+    seed = int(hashlib.sha256(filename.encode("utf-8")).hexdigest()[:8], 16)
+    return np.random.default_rng(seed)
+
 
 # Alphabet used for deterministic random-word generation (fuzzy datasets)
 ALPHABET = "abcdefghijklmnopqrstuvwxyz"
@@ -226,12 +241,16 @@ def apply_transforms(
 
         elif ttype == "fuzzy":
             # Generate fuzzy-match dataset: multiple misspelling variants per base term.
-            # Structure mirrors "expansion": variant_count × docs_per_variant × term_count.
-            # Variant 0 is the correctly-spelled base word; other variants apply
+            # Structure: variant_count × docs_per_variant. Variant 0 is the
+            # correctly-spelled base word; other variants apply
             # ``target_distance`` Levenshtein edits (insert/delete/substitute).
+            #
+            # ``min_word_length`` / ``max_word_length`` / ``target_distance``
+            # MUST match the corresponding fuzzy query-generator config so that
+            # each query resolves to the same base word its dataset variant 0
+            # holds. See TestGenerateFuzzyQueries.
             variant_count = t.get("variant_count", 5)
             docs_per_variant = t.get("docs_per_variant", 20)
-            term_count = t.get("term_count", 100)
             min_word_length = t.get("min_word_length", 5)
             max_word_length = t.get("max_word_length", 6)
             target_distance = t.get("target_distance", 1)
@@ -252,11 +271,9 @@ def apply_transforms(
                 # First variant is the correctly-spelled base word (matches queries)
                 variant = base_word
             else:
-                # Deterministic per-(term_id, variant_id) seed. We combine the two
-                # into a single integer (safe for variant_count up to 1_000_000)
-                # so the RNG is stable across Python versions - hash() of tuples
-                # is deterministic within one process but its algorithm is an
-                # implementation detail.
+                # Deterministic seed: term_id * 1_000_000 + variant_id
+                # (assumes variant_id < 1_000_000, which is trivially true for
+                # realistic ``variant_count`` values).
                 variant_seed = term_id * 1_000_000 + variant_id
                 variant_rng = random.Random(variant_seed)
                 variant = base_word
@@ -329,16 +346,25 @@ def generate_structured_npy(output_dir: Path, filename: str, config: dict) -> Pa
     """Generate a structured NPY combining vector + text/numeric/tag fields.
 
     The output is consumable by the dataset-enabled valkey-benchmark
-    (DATASET_FORMAT_NPY with a structured dtype). Each field is realized as:
+    (DATASET_FORMAT_NPY with a structured dtype). All random draws are
+    seeded via ``_make_rng(filename)`` so two invocations against the same
+    filename produce byte-identical output — required for cross-machine
+    benchmark comparability.
 
-      - vector         → ('name', 'f4', (dims,))  L2-normalized random Gaussian
-      - proximity_phrase → ('name', 'SN')  ASCII bytes, stores 'phrase{qid}'
-                          where qid = doc_num // repeats. A short single-token
-                          value is intentional so FT.SEARCH "phrase{i}" matches
-                          ~`repeats` docs (typically ~1% selectivity).
-      - numeric_range  → ('name', 'SN')  ASCII decimal string; NUMERIC index
-                          parses at ingest.
-      - tag_list       → ('name', 'SN')  ASCII bytes, single tag per doc.
+    Each field is realized as:
+
+      - vector       → ('name', 'f4', (dims,))  L2-normalized random Gaussian
+      - phrase_label → ('name', 'SN')  ASCII bytes, stores 'phrase{qid}' where
+                        qid = doc_num // repeats. A short single-token value is
+                        intentional: FT.SEARCH "phrase{i}" matches ~`repeats`
+                        docs (~1% selectivity at repeats=1000, docs=100k).
+      - proximity_phrase → deprecated alias for phrase_label, kept for
+                        backward compatibility with existing configs. In the
+                        NPY path it ignores term_count/combinations; use the
+                        CSV path if you need those semantics.
+      - numeric_range → ('name', 'SN')  ASCII decimal string; NUMERIC index
+                        parses at ingest.
+      - tag_list     → ('name', 'SN')  ASCII bytes, single tag per doc.
     """
     output = output_dir / filename
     if output.exists():
@@ -347,6 +373,7 @@ def generate_structured_npy(output_dir: Path, filename: str, config: dict) -> Pa
 
     doc_count = config["doc_count"]
     field_configs = build_field_configs(config)
+    rng = _make_rng(filename)
 
     # Build structured dtype from field transforms.
     dtype_list = []
@@ -357,7 +384,14 @@ def generate_structured_npy(output_dir: Path, filename: str, config: dict) -> Pa
             if ttype == "vector":
                 dims = t.get("dimensions", 256)
                 dtype_list.append((field_name, "f4", (dims,)))
-            elif ttype == "proximity_phrase":
+            elif ttype in ("phrase_label", "proximity_phrase"):
+                if ttype == "proximity_phrase":
+                    logging.warning(
+                        f"field '{field_name}': type 'proximity_phrase' in a "
+                        f"vector-bearing dataset is treated as 'phrase_label' "
+                        f"(term_count / combinations are ignored). Rename to "
+                        f"'phrase_label' to silence this warning."
+                    )
                 size = field.get("size", 50)
                 dtype_list.append((field_name, f"S{size}"))
             elif ttype == "numeric_range":
@@ -379,15 +413,17 @@ def generate_structured_npy(output_dir: Path, filename: str, config: dict) -> Pa
 
     if not dtype_list:
         raise ValueError(
-            f"No supported fields (vector / proximity_phrase / numeric_range / "
-            f"tag_list) declared for {filename}; nothing to generate"
+            f"No supported fields (vector / phrase_label / proximity_phrase / "
+            f"numeric_range / tag_list) declared for {filename}; nothing to "
+            f"generate"
         )
 
     logging.info(f"Generating {filename} ({doc_count} docs, {len(dtype_list)} fields)")
     data = np.zeros(doc_count, dtype=dtype_list)
 
     # Fill each field. All inner loops are numpy-vectorized so throughput scales
-    # linearly with doc_count instead of degrading at 10^5+ rows.
+    # linearly with doc_count instead of degrading at 10^5+ rows. All random
+    # draws go through the seeded `rng` for byte-identical reproducibility.
     for field in field_configs:
         field_name = field["name"]
         for t in field.get("transforms", []):
@@ -395,10 +431,10 @@ def generate_structured_npy(output_dir: Path, filename: str, config: dict) -> Pa
 
             if ttype == "vector":
                 dims = t.get("dimensions", 256)
-                vectors = np.random.randn(doc_count, dims).astype(np.float32)
+                vectors = rng.standard_normal((doc_count, dims), dtype=np.float32)
                 data[field_name] = _l2_normalize(vectors)
 
-            elif ttype == "proximity_phrase":
+            elif ttype in ("phrase_label", "proximity_phrase"):
                 # Short single-token value: "phrase{qid}". With repeats=1000 and
                 # doc_count=100_000, there are 100 unique phrase ids and each
                 # matches ~1000 docs when queried.
@@ -415,15 +451,14 @@ def generate_structured_npy(output_dir: Path, filename: str, config: dict) -> Pa
             elif ttype == "numeric_range":
                 min_val = t.get("min", 0)
                 max_val = t.get("max", 1000)
-                prices = np.random.uniform(min_val, max_val, doc_count)
+                prices = rng.uniform(min_val, max_val, doc_count)
                 formatted = np.char.mod("%.2f", prices)  # returns U-dtype
                 data[field_name] = formatted.astype(data[field_name].dtype)
 
             elif ttype == "tag_list":
                 tags = t.get("tags", ["electronics", "books", "clothing"])
-                # np.random.choice picks a random tag per row; encode once via
-                # the target byte dtype so we skip the per-row .encode() loop.
-                choices = np.random.choice(tags, size=doc_count)
+                # Pick a random tag per row via the seeded rng.
+                choices = rng.choice(tags, size=doc_count)
                 data[field_name] = choices.astype(data[field_name].dtype)
 
     np.save(output, data)
@@ -699,10 +734,10 @@ def generate_queries(output_dir: Path, config: dict, filename: str) -> Path:
         elif query_type == "vector":
             # Structured NPY: (search_term: SN, query_vector: f4[dims]).
             # Terms are 'phrase{i}' so they match generate_structured_npy() ingest
-            # (proximity_phrase transform stores 'phrase{qid}' per doc). Query
-            # vectors are L2-normalized random Gaussians. A companion CSV of just
-            # the search terms is also written so text-only validators / fallback
-            # tools without numpy still work.
+            # (phrase_label / proximity_phrase transform stores 'phrase{qid}' per
+            # doc). Query vectors are L2-normalized random Gaussians drawn from
+            # a filename-seeded RNG so two invocations produce byte-identical
+            # output. A companion CSV of just the search terms is also written.
             dimensions = config.get("dimensions", 256)
             npy_path = output_dir / Path(filename).with_suffix(".npy")
 
@@ -711,6 +746,7 @@ def generate_queries(output_dir: Path, config: dict, filename: str) -> Path:
                     f"Generating {npy_path.name} "
                     f"(structured: search_term + query_vector)"
                 )
+                rng = _make_rng(npy_path.name)
                 dtype = [
                     ("search_term", "S20"),
                     ("query_vector", "f4", (dimensions,)),
@@ -722,7 +758,9 @@ def generate_queries(output_dir: Path, config: dict, filename: str) -> Path:
                     dtype=data["search_term"].dtype,
                 )
                 # query_vector: random Gaussian, L2-normalized in a single pass.
-                vectors = np.random.randn(num_queries, dimensions).astype(np.float32)
+                vectors = rng.standard_normal(
+                    (num_queries, dimensions), dtype=np.float32
+                )
                 data["query_vector"] = _l2_normalize(vectors)
                 np.save(npy_path, data)
                 logging.info(f"Complete: {npy_path.name}")

--- a/scripts/setup_datasets.py
+++ b/scripts/setup_datasets.py
@@ -5,11 +5,15 @@ import argparse
 import csv
 import json
 import logging
+import random
 import subprocess
 import sys
 import urllib.request
 import xml.etree.ElementTree as ET
 from pathlib import Path
+
+# Alphabet used for deterministic random-word generation (fuzzy datasets)
+ALPHABET = "abcdefghijklmnopqrstuvwxyz"
 
 # Constants for query generation
 STOP_WORDS = {
@@ -47,6 +51,42 @@ STOP_WORDS = {
     "will",
     "with",
 }
+
+
+def _generate_random_word(rng: random.Random, min_length: int, max_length: int) -> str:
+    """Generate a deterministic random word using the supplied local RNG.
+
+    A local RNG (not the global one) is used so that fuzzy dataset generation
+    remains reproducible regardless of other transforms.
+    """
+    word_length = rng.randint(min_length, max_length)
+    return "".join(rng.choices(ALPHABET, k=word_length))
+
+
+def _apply_fuzzy_edit(word: str, edit_type: str, rng: random.Random) -> str:
+    """Apply a single Levenshtein edit (insert/delete/substitute) to ``word``.
+
+    Uses the supplied local RNG for reproducibility. Substitute retries until a
+    different character is produced to avoid no-op edits.
+    """
+    if len(word) < 2:
+        return word
+
+    if edit_type == "insert":
+        pos = rng.randint(0, len(word))
+        return word[:pos] + rng.choice(ALPHABET) + word[pos:]
+    if edit_type == "delete":
+        pos = rng.randint(0, len(word) - 1)
+        return word[:pos] + word[pos + 1 :]
+    if edit_type == "substitute":
+        pos = rng.randint(0, len(word) - 1)
+        original_char = word[pos]
+        new_char = rng.choice(ALPHABET)
+        while new_char == original_char and len(ALPHABET) > 1:
+            new_char = rng.choice(ALPHABET)
+        return word[:pos] + new_char + word[pos + 1 :]
+
+    return word
 
 
 def download_wikipedia(output_dir: Path) -> Path:
@@ -183,6 +223,48 @@ def apply_transforms(
                 parts.extend(terms)
                 content = " ".join(parts)
 
+        elif ttype == "fuzzy":
+            # Generate fuzzy-match dataset: multiple misspelling variants per base term.
+            # Structure mirrors "expansion": variant_count × docs_per_variant × term_count.
+            # Variant 0 is the correctly-spelled base word; other variants apply
+            # ``target_distance`` Levenshtein edits (insert/delete/substitute).
+            variant_count = t.get("variant_count", 5)
+            docs_per_variant = t.get("docs_per_variant", 20)
+            term_count = t.get("term_count", 100)
+            min_word_length = t.get("min_word_length", 5)
+            max_word_length = t.get("max_word_length", 6)
+            target_distance = t.get("target_distance", 1)
+
+            # Determine which term / variant this document belongs to
+            docs_per_term = variant_count * docs_per_variant
+            term_id = ((doc_num - 1) // docs_per_term) + 1
+            within_term = (doc_num - 1) % docs_per_term
+            variant_id = within_term // docs_per_variant
+
+            # Deterministic base word seeded by term_id
+            term_rng = random.Random(term_id)
+            base_word = _generate_random_word(
+                term_rng, min_word_length, max_word_length
+            )
+
+            if variant_id == 0:
+                # First variant is the correctly-spelled base word (matches queries)
+                variant = base_word
+            else:
+                # Deterministic per-(term_id, variant_id) seed. We combine the two
+                # into a single integer (safe for variant_count up to 1_000_000)
+                # so the RNG is stable across Python versions - hash() of tuples
+                # is deterministic within one process but its algorithm is an
+                # implementation detail.
+                variant_seed = term_id * 1_000_000 + variant_id
+                variant_rng = random.Random(variant_seed)
+                variant = base_word
+                for _ in range(target_distance):
+                    edit_type = variant_rng.choice(["insert", "delete", "substitute"])
+                    variant = _apply_fuzzy_edit(variant, edit_type, variant_rng)
+
+            content = variant
+
         elif ttype == "expansion":
             # Generate expansion variants: prefix_a suffix_a, prefix_aa suffix_aa, etc.
             # Tests wildcard expansion with multiple documents per variant
@@ -210,16 +292,12 @@ def apply_transforms(
 
         elif ttype == "numeric_range":
             # Generate random numeric values in range
-            import random
-
             min_val = t.get("min", 0)
             max_val = t.get("max", 100)
             content = str(random.uniform(min_val, max_val))
 
         elif ttype == "tag_list":
             # Generate tag combinations
-            import random
-
             tags = t.get("tags", ["tag1", "tag2", "tag3"])
             # Select 1-2 random tags and join with pipe
             num_tags = random.randint(1, min(2, len(tags)))
@@ -456,6 +534,33 @@ def generate_queries(output_dir: Path, config: dict, filename: str) -> Path:
             writer.writerow(["term"])
             for term_id in range(1, num_queries + 1):
                 writer.writerow([f"term{term_id:03d}"])
+
+        elif query_type == "fuzzy":
+            # Generate the correctly-spelled base words for fuzzy datasets.
+            # Uses the same term_id → base_word mapping as the fuzzy transform,
+            # so each query is guaranteed to have matching variants in the dataset.
+            min_length = config.get("min_word_length", 5)
+            max_length = config.get("max_word_length", 6)
+
+            writer.writerow(["term"])
+            for term_id in range(1, num_queries + 1):
+                term_rng = random.Random(term_id)
+                base_word = _generate_random_word(term_rng, min_length, max_length)
+                writer.writerow([base_word])
+
+        elif query_type == "tag_only":
+            # Generate tag-only queries for composed TAG filter tests.
+            # Rotates through the provided tag list to produce ``doc_count`` queries.
+            tags = config.get(
+                "tags", ["electronics", "books", "clothing", "food", "sports"]
+            )
+            if not tags:
+                logging.error(f"tag_only query {filename} needs non-empty 'tags' list")
+                return output
+
+            writer.writerow(["category"])
+            for i in range(num_queries):
+                writer.writerow([tags[i % len(tags)]])
 
     logging.info(f"Complete: {filename} ({num_queries} queries)")
     return output

--- a/scripts/setup_datasets.py
+++ b/scripts/setup_datasets.py
@@ -11,6 +11,7 @@ import sys
 import urllib.request
 import xml.etree.ElementTree as ET
 from pathlib import Path
+import numpy as np
 
 # Alphabet used for deterministic random-word generation (fuzzy datasets)
 ALPHABET = "abcdefghijklmnopqrstuvwxyz"
@@ -304,7 +305,130 @@ def apply_transforms(
             selected = random.sample(tags, num_tags)
             content = "|".join(selected)
 
+        elif ttype == "vector":
+            # Vector fields live in structured NPY, not CSV. This marker exists
+            # so build_field_configs()/generate_csv_dataset() can detect a vector
+            # field and route generation to generate_structured_npy().
+            content = ""
+
     return content[:field_size]
+
+
+def _l2_normalize(vectors: "np.ndarray") -> "np.ndarray":
+    """Return `vectors` scaled to unit L2 norm along the last axis (in-place safe).
+
+    Rows with zero norm are left as-is (division would produce NaN). In practice
+    this never triggers for `np.random.randn` output, but keeping the branch
+    keeps the function safe for any caller that might pass sparser input.
+    """
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    return np.divide(vectors, norms, out=np.zeros_like(vectors), where=(norms != 0))
+
+
+def generate_structured_npy(output_dir: Path, filename: str, config: dict) -> Path:
+    """Generate a structured NPY combining vector + text/numeric/tag fields.
+
+    The output is consumable by the dataset-enabled valkey-benchmark
+    (DATASET_FORMAT_NPY with a structured dtype). Each field is realized as:
+
+      - vector         → ('name', 'f4', (dims,))  L2-normalized random Gaussian
+      - proximity_phrase → ('name', 'SN')  ASCII bytes, stores 'phrase{qid}'
+                          where qid = doc_num // repeats. A short single-token
+                          value is intentional so FT.SEARCH "phrase{i}" matches
+                          ~`repeats` docs (typically ~1% selectivity).
+      - numeric_range  → ('name', 'SN')  ASCII decimal string; NUMERIC index
+                          parses at ingest.
+      - tag_list       → ('name', 'SN')  ASCII bytes, single tag per doc.
+    """
+    output = output_dir / filename
+    if output.exists():
+        logging.info(f"Exists: {filename}")
+        return output
+
+    doc_count = config["doc_count"]
+    field_configs = build_field_configs(config)
+
+    # Build structured dtype from field transforms.
+    dtype_list = []
+    for field in field_configs:
+        field_name = field["name"]
+        for t in field.get("transforms", []):
+            ttype = t.get("type")
+            if ttype == "vector":
+                dims = t.get("dimensions", 256)
+                dtype_list.append((field_name, "f4", (dims,)))
+            elif ttype == "proximity_phrase":
+                size = field.get("size", 50)
+                dtype_list.append((field_name, f"S{size}"))
+            elif ttype == "numeric_range":
+                size = field.get("size", 15)
+                # Sanity: an unsigned decimal with 2 fractional digits needs
+                # len(str(int(max_val))) + 3 bytes at minimum. Fail loudly at
+                # generation time rather than silently truncating in the file.
+                max_val = t.get("max", 1000)
+                needed = len(f"{max_val:.2f}")
+                if size < needed:
+                    raise ValueError(
+                        f"numeric_range field '{field_name}' has size={size} "
+                        f"but max={max_val} requires at least {needed} bytes"
+                    )
+                dtype_list.append((field_name, f"S{size}"))
+            elif ttype == "tag_list":
+                size = field.get("size", 30)
+                dtype_list.append((field_name, f"S{size}"))
+
+    if not dtype_list:
+        raise ValueError(
+            f"No supported fields (vector / proximity_phrase / numeric_range / "
+            f"tag_list) declared for {filename}; nothing to generate"
+        )
+
+    logging.info(f"Generating {filename} ({doc_count} docs, {len(dtype_list)} fields)")
+    data = np.zeros(doc_count, dtype=dtype_list)
+
+    # Fill each field. All inner loops are numpy-vectorized so throughput scales
+    # linearly with doc_count instead of degrading at 10^5+ rows.
+    for field in field_configs:
+        field_name = field["name"]
+        for t in field.get("transforms", []):
+            ttype = t.get("type")
+
+            if ttype == "vector":
+                dims = t.get("dimensions", 256)
+                vectors = np.random.randn(doc_count, dims).astype(np.float32)
+                data[field_name] = _l2_normalize(vectors)
+
+            elif ttype == "proximity_phrase":
+                # Short single-token value: "phrase{qid}". With repeats=1000 and
+                # doc_count=100_000, there are 100 unique phrase ids and each
+                # matches ~1000 docs when queried.
+                repeats = t.get("repeats", 1000)
+                qids = np.arange(doc_count) // repeats
+                # Encode the small set of unique labels once and gather.
+                unique_qids = np.unique(qids)
+                labels = np.array(
+                    [f"phrase{q}".encode("ascii") for q in unique_qids],
+                    dtype=data[field_name].dtype,
+                )
+                data[field_name] = labels[qids - unique_qids[0]]
+
+            elif ttype == "numeric_range":
+                min_val = t.get("min", 0)
+                max_val = t.get("max", 1000)
+                prices = np.random.uniform(min_val, max_val, doc_count)
+                formatted = np.char.mod("%.2f", prices)  # returns U-dtype
+                data[field_name] = formatted.astype(data[field_name].dtype)
+
+            elif ttype == "tag_list":
+                tags = t.get("tags", ["electronics", "books", "clothing"])
+                # np.random.choice picks a random tag per row; encode once via
+                # the target byte dtype so we skip the per-row .encode() loop.
+                choices = np.random.choice(tags, size=doc_count)
+                data[field_name] = choices.astype(data[field_name].dtype)
+
+    np.save(output, data)
+    logging.info(f"Complete: {filename}")
+    return output
 
 
 def generate_csv_dataset(
@@ -319,6 +443,16 @@ def generate_csv_dataset(
 
     doc_count = config["doc_count"]
     field_configs = build_field_configs(config)
+
+    # If any field has a `vector` transform, output is a structured NPY (not CSV).
+    # Route to generate_structured_npy() and rewrite the .csv suffix to .npy.
+    has_vector = any(
+        any(t.get("type") == "vector" for t in field.get("transforms", []))
+        for field in field_configs
+    )
+    if has_vector:
+        npy_filename = str(Path(filename).with_suffix(".npy"))
+        return generate_structured_npy(output_dir, npy_filename, config)
 
     # Check if any field needs Wikipedia
     needs_wiki = any(
@@ -562,6 +696,42 @@ def generate_queries(output_dir: Path, config: dict, filename: str) -> Path:
             for i in range(num_queries):
                 writer.writerow([tags[i % len(tags)]])
 
+        elif query_type == "vector":
+            # Structured NPY: (search_term: SN, query_vector: f4[dims]).
+            # Terms are 'phrase{i}' so they match generate_structured_npy() ingest
+            # (proximity_phrase transform stores 'phrase{qid}' per doc). Query
+            # vectors are L2-normalized random Gaussians. A companion CSV of just
+            # the search terms is also written so text-only validators / fallback
+            # tools without numpy still work.
+            dimensions = config.get("dimensions", 256)
+            npy_path = output_dir / Path(filename).with_suffix(".npy")
+
+            if not npy_path.exists():
+                logging.info(
+                    f"Generating {npy_path.name} "
+                    f"(structured: search_term + query_vector)"
+                )
+                dtype = [
+                    ("search_term", "S20"),
+                    ("query_vector", "f4", (dimensions,)),
+                ]
+                data = np.zeros(num_queries, dtype=dtype)
+                # search_term: deterministic 'phrase{i}' → vectorized encode.
+                data["search_term"] = np.array(
+                    [f"phrase{i}".encode("ascii") for i in range(num_queries)],
+                    dtype=data["search_term"].dtype,
+                )
+                # query_vector: random Gaussian, L2-normalized in a single pass.
+                vectors = np.random.randn(num_queries, dimensions).astype(np.float32)
+                data["query_vector"] = _l2_normalize(vectors)
+                np.save(npy_path, data)
+                logging.info(f"Complete: {npy_path.name}")
+
+            # Companion CSV with just the terms (validate_queries.py fallback).
+            writer.writerow(["search_term"])
+            for i in range(num_queries):
+                writer.writerow([f"phrase{i}"])
+
     logging.info(f"Complete: {filename} ({num_queries} queries)")
     return output
 
@@ -609,16 +779,32 @@ def main():
     wiki_file = download_wikipedia(args.output_dir) if needs_wiki else None
 
     for filename in files_to_gen:
-        if filename in dataset_configs:
-            if filename.endswith(".csv"):
-                # CSV format - pass wiki_file if needed
+        # A scenario may reference `foo.npy` while the dataset_generation key
+        # is `foo.csv` (structured NPY is produced by the CSV path when a
+        # vector field is present). Fall back to the .csv key in that case.
+        config_key = filename
+        if filename.endswith(".npy") and filename not in dataset_configs:
+            csv_key = str(Path(filename).with_suffix(".csv"))
+            if csv_key in dataset_configs:
+                config_key = csv_key
+
+        if config_key in dataset_configs:
+            if config_key.endswith(".csv"):
+                # CSV format - pass wiki_file if needed. Auto-routes to
+                # structured NPY internally when any field is a vector.
                 generate_csv_dataset(
-                    args.output_dir, dataset_configs[filename], filename, wiki_file
+                    args.output_dir,
+                    dataset_configs[config_key],
+                    config_key,
+                    wiki_file,
                 )
             elif wiki_file:
                 # XML format - needs Wikipedia
                 generate_dataset(
-                    args.output_dir, wiki_file, dataset_configs[filename], filename
+                    args.output_dir,
+                    wiki_file,
+                    dataset_configs[config_key],
+                    config_key,
                 )
 
     # Generate query CSVs

--- a/tests/test_client_runner_logic.py
+++ b/tests/test_client_runner_logic.py
@@ -1,7 +1,9 @@
 """Unit tests for pure logic methods on ClientRunner from valkey_benchmark.py."""
 
-import pytest
 from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from valkey_benchmark import ClientRunner
 
@@ -518,3 +520,257 @@ class TestIterateSimpleScenarios:
         first = items[0]
         for key in ("command", "data_size", "pipeline", "clients", "requests"):
             assert key in first
+
+
+# ---------------------------------------------------------------------------
+# Mixed workload: _normalize_mixed_configs, _get_cpu_for_mixed_process,
+# _run_mixed_workload
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mixed_runner(minimal_valid_config):
+    """ClientRunner configured for mixed-workload tests.
+
+    Adds cpu_allocation (used by _get_cpu_for_mixed_process) and a set of
+    client CPU ranges wide enough to test partitioning.
+    """
+    cfg = {
+        **minimal_valid_config,
+        "cpu_allocation": {"cores_per_server": 1, "cores_per_client": 2},
+    }
+    runner = ClientRunner(
+        commit_id="abc123",
+        config=cfg,
+        cluster_mode=False,
+        tls_mode=False,
+        target_ip="127.0.0.1",
+        results_dir=Path("/tmp/test_results"),
+        valkey_path="/tmp/valkey",
+        valkey_benchmark_path="src/valkey-benchmark",
+    )
+    runner.client_cpu_ranges = ["10-11", "12-13", "14-15"]
+    return runner
+
+
+@pytest.fixture
+def mixed_scenario():
+    """Representative mixed scenario with 1 write + 2 read sub-scenarios."""
+    return {
+        "id": "j",
+        "type": "mixed",
+        "duration": 60,
+        "pipeline": 2,
+        "writes": [{"id": "w1", "command": "HSET doc:x f v", "clients": 3}],
+        "reads": [
+            {"id": "r1", "command": "FT.SEARCH idx q1", "clients": 5},
+            {"id": "r2", "command": "FT.SEARCH idx q2", "clients": 5},
+        ],
+    }
+
+
+class TestNormalizeMixedConfigs:
+    """Tests for ClientRunner._normalize_mixed_configs."""
+
+    def test_sub_scenario_duration_overrides_parent(self, mixed_runner):
+        """Sub-scenario duration must NOT be replaced by parent duration."""
+        scenario = {
+            "id": "j",
+            "duration": 60,
+            "writes": [
+                {"id": "w1", "command": "HSET k f v", "clients": 1, "duration": 10}
+            ],
+            "reads": [{"id": "r1", "command": "FT.SEARCH idx q", "clients": 1}],
+        }
+        writes, reads = mixed_runner._normalize_mixed_configs(scenario)
+        assert writes[0]["duration"] == 10  # override preserved
+        assert reads[0]["duration"] == 60  # parent propagated
+
+    def test_cluster_execution_only_propagated_when_parent_sets_it(self, mixed_runner):
+        """cluster_execution is set on subs only when the parent has it."""
+        with_ce = {
+            "id": "j",
+            "cluster_execution": "single",
+            "writes": [{"id": "w1", "command": "HSET k f v", "clients": 1}],
+            "reads": [],
+        }
+        writes, _ = mixed_runner._normalize_mixed_configs(with_ce)
+        assert writes[0]["cluster_execution"] == "single"
+
+        without_ce = {
+            "id": "j",
+            "writes": [{"id": "w1", "command": "HSET k f v", "clients": 1}],
+            "reads": [],
+        }
+        writes, _ = mixed_runner._normalize_mixed_configs(without_ce)
+        assert "cluster_execution" not in writes[0]
+
+
+class TestGetCpuForMixedProcess:
+    """Tests for ClientRunner._get_cpu_for_mixed_process."""
+
+    def test_partitions_pool_by_cores_per_client(self, mixed_runner):
+        """cores_per_client=2 starting at core 10 → 10-11, 12-13, 14-15."""
+        assert mixed_runner._get_cpu_for_mixed_process(0) == "10-11"
+        assert mixed_runner._get_cpu_for_mixed_process(1) == "12-13"
+        assert mixed_runner._get_cpu_for_mixed_process(2) == "14-15"
+
+    def test_single_core_per_client_returns_bare_number(self, minimal_valid_config):
+        """When only 1 core per client, output must be '20' not '20-20'."""
+        cfg = {
+            **minimal_valid_config,
+            "cpu_allocation": {"cores_per_server": 1, "cores_per_client": 1},
+        }
+        runner = ClientRunner(
+            commit_id="abc",
+            config=cfg,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp"),
+            valkey_path="/tmp",
+        )
+        runner.client_cpu_ranges = ["20-25"]
+        assert runner._get_cpu_for_mixed_process(0) == "20"
+        assert runner._get_cpu_for_mixed_process(1) == "21"
+
+    def test_first_range_as_single_core_parses_correctly(self, minimal_valid_config):
+        """When client_cpu_ranges[0] has no dash it still parses as an int."""
+        cfg = {
+            **minimal_valid_config,
+            "cpu_allocation": {"cores_per_server": 1, "cores_per_client": 2},
+        }
+        runner = ClientRunner(
+            commit_id="abc",
+            config=cfg,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp"),
+            valkey_path="/tmp",
+        )
+        runner.client_cpu_ranges = ["30"]
+        assert runner._get_cpu_for_mixed_process(0) == "30-31"
+        assert runner._get_cpu_for_mixed_process(1) == "32-33"
+
+
+def _popen_mock(stdout: str, returncode: int = 0):
+    """Return a MagicMock that mimics ``subprocess.Popen`` for one child."""
+    proc = MagicMock()
+    proc.communicate.return_value = (stdout, "")
+    proc.returncode = returncode
+    return proc
+
+
+_MIXED_CSV = _make_csv(
+    [
+        {
+            "test": "HSET",
+            "rps": "1000.0",
+            "avg_latency_ms": "1.0",
+            "min_latency_ms": "0.5",
+            "p50_latency_ms": "1.0",
+            "p95_latency_ms": "1.5",
+            "p99_latency_ms": "2.0",
+            "max_latency_ms": "3.0",
+        }
+    ]
+)
+
+
+class TestRunMixedWorkload:
+    """Tests for ClientRunner._run_mixed_workload (Popen mocked)."""
+
+    def test_metrics_have_correct_test_id_and_phase_per_sub_scenario(
+        self, mixed_runner, mixed_scenario
+    ):
+        """Every produced metric must be attributable to its sub-scenario id."""
+        metrics_processor = MagicMock()
+        metrics_processor.create_metrics.return_value = {"rps": 1000.0}
+
+        with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
+            mock_popen.side_effect = [_popen_mock(_MIXED_CSV) for _ in range(3)]
+
+            result = mixed_runner._run_mixed_workload(
+                mixed_scenario,
+                group_id=1,
+                config_set={},
+                metrics_processor=metrics_processor,
+                warmup_duration=0,
+                commit_time="2026-01-01T00:00:00Z",
+                scenario_id="j",
+            )
+
+        assert result is not None and len(result) == 3
+        test_ids = {m["test_id"] for m in result}
+        assert test_ids == {"1_j_write_w1", "1_j_read_r1", "1_j_read_r2"}
+
+        by_phase = {m["test_id"]: m["test_phase"] for m in result}
+        assert by_phase["1_j_write_w1"] == "mixed_write"
+        assert by_phase["1_j_read_r1"] == "mixed_read"
+        assert by_phase["1_j_read_r2"] == "mixed_read"
+
+    def test_warmup_mode_still_spawns_processes_but_returns_no_metrics(
+        self, mixed_runner, mixed_scenario
+    ):
+        """Warmup (metrics_processor=None) must still drain workload processes."""
+        with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
+            mock_popen.side_effect = [_popen_mock(_MIXED_CSV) for _ in range(3)]
+
+            result = mixed_runner._run_mixed_workload(
+                mixed_scenario,
+                group_id=1,
+                config_set={},
+                metrics_processor=None,
+                warmup_duration=0,
+                commit_time="2026-01-01T00:00:00Z",
+                scenario_id="j",
+            )
+
+        assert mock_popen.call_count == 3
+        assert result is None
+
+    def test_failed_process_produces_no_metric_for_that_sub_scenario(
+        self, mixed_runner, mixed_scenario
+    ):
+        """Non-zero exit for one process must not poison metrics for others."""
+        metrics_processor = MagicMock()
+        metrics_processor.create_metrics.return_value = {"rps": 1000.0}
+
+        with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
+            mock_popen.side_effect = [
+                _popen_mock("", returncode=1),  # w1 fails
+                _popen_mock(_MIXED_CSV),  # r1 ok
+                _popen_mock(_MIXED_CSV),  # r2 ok
+            ]
+
+            result = mixed_runner._run_mixed_workload(
+                mixed_scenario,
+                group_id=1,
+                config_set={},
+                metrics_processor=metrics_processor,
+                warmup_duration=0,
+                commit_time="2026-01-01T00:00:00Z",
+                scenario_id="j",
+            )
+
+        test_ids = {m["test_id"] for m in result}
+        assert "1_j_write_w1" not in test_ids
+        assert "1_j_read_r1" in test_ids
+        assert "1_j_read_r2" in test_ids
+
+    def test_empty_writes_and_reads_returns_none_without_spawning(self, mixed_runner):
+        """A scenario with no sub-scenarios must not spawn anything."""
+        scenario = {"id": "j", "duration": 60, "writes": [], "reads": []}
+        with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
+            result = mixed_runner._run_mixed_workload(
+                scenario,
+                group_id=1,
+                config_set={},
+                metrics_processor=MagicMock(),
+                warmup_duration=0,
+                commit_time="2026-01-01T00:00:00Z",
+            )
+
+        assert result is None
+        assert mock_popen.call_count == 0

--- a/tests/test_client_runner_logic.py
+++ b/tests/test_client_runner_logic.py
@@ -779,3 +779,64 @@ class TestRunMixedWorkload:
 
         assert result is None
         assert mock_popen.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# _create_mixed_metric — signature guard using the REAL MetricsProcessor
+# ---------------------------------------------------------------------------
+#
+# Other mixed-workload tests mock MetricsProcessor via ``side_effect``. That
+# accepts any positional/keyword combination, so a drift between
+# _create_mixed_metric's call site and MetricsProcessor.create_metrics's real
+# signature would pass mocked tests but blow up at runtime.
+#
+# This test wires the two together with a real MetricsProcessor to catch that
+# drift class of bug.
+
+
+class TestCreateMixedMetricRealProcessor:
+    """Signature-drift guard: _create_mixed_metric ↔ MetricsProcessor.create_metrics."""
+
+    def test_real_processor_accepts_all_positional_args(self, mixed_runner):
+        from process_metrics import MetricsProcessor
+
+        real_processor = MetricsProcessor(
+            commit_id="abc123",
+            cluster_mode=False,
+            tls_mode=False,
+            commit_time="2026-01-01T00:00:00Z",
+        )
+
+        # Minimal well-formed CSV row (matches _parse_csv_row output shape).
+        row = {
+            "test": "FT.SEARCH",
+            "rps": "1000.0",
+            "avg_latency_ms": "1.0",
+            "min_latency_ms": "0.5",
+            "p50_latency_ms": "1.0",
+            "p95_latency_ms": "2.0",
+            "p99_latency_ms": "3.0",
+            "max_latency_ms": "5.0",
+        }
+        sub_cfg = {"command": "FT.SEARCH rd0 hello", "clients": 10, "pipeline": 1}
+        parent_scenario = {"duration": 60}
+
+        metric = mixed_runner._create_mixed_metric(
+            row=row,
+            sub_cfg=sub_cfg,
+            parent_scenario=parent_scenario,
+            group_id=1,
+            scenario_id="j",
+            sub_id="r1",
+            phase="read",
+            config_set={},
+            warmup_duration=0,
+            metrics_processor=real_processor,
+        )
+
+        # If create_metrics's signature drifts (arg reorder, rename, added
+        # required kwarg), the call above raises TypeError before we get here.
+        assert metric is not None
+        assert metric["test_id"] == "1_j_read_r1"
+        assert metric["test_phase"] == "mixed_read"
+        assert metric["rps"] == 1000.0

--- a/tests/test_client_runner_logic.py
+++ b/tests/test_client_runner_logic.py
@@ -685,8 +685,12 @@ class TestRunMixedWorkload:
         self, mixed_runner, mixed_scenario
     ):
         """Every produced metric must be attributable to its sub-scenario id."""
+        # Use side_effect (not return_value) so each call returns a *fresh*
+        # dict. _create_mixed_metric mutates the dict returned by
+        # create_metrics; a shared return_value would cause every metric to
+        # end up as the same dict with the last-written test_id.
         metrics_processor = MagicMock()
-        metrics_processor.create_metrics.return_value = {"rps": 1000.0}
+        metrics_processor.create_metrics.side_effect = lambda *a, **kw: {"rps": 1000.0}
 
         with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
             mock_popen.side_effect = [_popen_mock(_MIXED_CSV) for _ in range(3)]
@@ -734,8 +738,9 @@ class TestRunMixedWorkload:
         self, mixed_runner, mixed_scenario
     ):
         """Non-zero exit for one process must not poison metrics for others."""
+        # side_effect returns a fresh dict per call (see other test for why).
         metrics_processor = MagicMock()
-        metrics_processor.create_metrics.return_value = {"rps": 1000.0}
+        metrics_processor.create_metrics.side_effect = lambda *a, **kw: {"rps": 1000.0}
 
         with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
             mock_popen.side_effect = [

--- a/tests/test_scenario_expansion.py
+++ b/tests/test_scenario_expansion.py
@@ -126,3 +126,29 @@ class TestExpandScenarioWithOptions:
 
         assert scenario["id"] == original_id
         assert scenario["command"] == original_cmd
+
+
+class TestExpandScenarioMixedOptions:
+    """For mixed scenarios, options must apply to read sub-scenarios (not writes,
+    and not to a non-existent top-level command)."""
+
+    def test_mixed_options_applied_to_reads_not_writes(self, minimal_client_runner):
+        """Flag is appended to every read command; write commands are unchanged."""
+        scenario = {
+            "id": "j",
+            "type": "mixed",
+            "writes": [{"id": "a", "command": "HSET doc:x field v", "clients": 3}],
+            "reads": [
+                {"id": "b", "command": "FT.SEARCH idx q1", "clients": 7},
+                {"id": "c", "command": "FT.SEARCH idx q2", "clients": 7},
+            ],
+            "options": {"NOCONTENT": "_nc"},
+        }
+        result = minimal_client_runner._expand_scenario_options(scenario)
+
+        assert len(result) == 1
+        variant = result[0]
+        assert variant["id"] == "j_nc"
+        assert variant["writes"][0]["command"] == "HSET doc:x field v"
+        assert variant["reads"][0]["command"] == "FT.SEARCH idx q1 NOCONTENT"
+        assert variant["reads"][1]["command"] == "FT.SEARCH idx q2 NOCONTENT"

--- a/tests/test_setup_datasets.py
+++ b/tests/test_setup_datasets.py
@@ -192,3 +192,67 @@ class TestGenerateTagOnlyQueries:
             "clothing",
             "electronics",
         ]
+
+
+# ---- vector NPY: dataset ↔ query token alignment ---------------------------
+
+
+class TestVectorHybridQueryAlignment:
+    """The vector benchmark's ingest side stores ``phrase{qid}`` per doc, and
+    the vector query side emits ``phrase{i}`` as its ``search_term``. If either
+    side changes format (say, ``phrase_{i}`` or ``phrase-{i}``), Group 15 will
+    silently return zero results and the whole KNN + text-prefilter benchmark
+    becomes meaningless. This is the same class of fragile contract that
+    ``TestGenerateFuzzyQueries`` guards for fuzzy.
+    """
+
+    def test_every_query_term_appears_in_the_hybrid_dataset(self, tmp_path: Path):
+        try:
+            import numpy as np
+        except ImportError:  # pragma: no cover - numpy is a hard dep
+            import pytest
+
+            pytest.skip("numpy not installed")
+
+        dims = 4
+        doc_count = 10
+        repeats = 2  # → 5 distinct phrase ids: phrase0..phrase4
+        num_queries = 5
+
+        dataset_config = {
+            "doc_count": doc_count,
+            "fields": [
+                {
+                    "name": "title",
+                    "size": 50,
+                    "transforms": [
+                        {
+                            "type": "proximity_phrase",
+                            "term_count": 1,
+                            "combinations": 1,
+                            "repeats": repeats,
+                        }
+                    ],
+                },
+                {
+                    "name": "embedding",
+                    "size": 1,
+                    "transforms": [{"type": "vector", "dimensions": dims}],
+                },
+            ],
+        }
+        setup_datasets.generate_structured_npy(tmp_path, "hybrid.npy", dataset_config)
+
+        query_config = {"type": "vector", "doc_count": num_queries, "dimensions": dims}
+        setup_datasets.generate_queries(tmp_path, query_config, "queries.csv")
+
+        hybrid = np.load(tmp_path / "hybrid.npy", allow_pickle=False)
+        queries = np.load(tmp_path / "queries.npy", allow_pickle=False)
+
+        titles = {t.rstrip(b"\x00").decode("ascii") for t in hybrid["title"]}
+        for term in queries["search_term"]:
+            decoded = term.rstrip(b"\x00").decode("ascii")
+            assert decoded in titles, (
+                f"query term {decoded!r} does not appear in hybrid dataset titles "
+                f"({sorted(titles)}) — KNN benchmark would silently return no hits"
+            )

--- a/tests/test_setup_datasets.py
+++ b/tests/test_setup_datasets.py
@@ -1,0 +1,194 @@
+"""Unit tests for the fuzzy transform and its matching query generators.
+
+Focus is on the non-obvious behavior that would break the benchmark:
+
+  - each Levenshtein edit type must transform length correctly and (for
+    substitute) must actually change a character
+  - the ``len < 2`` early return in ``_apply_fuzzy_edit`` (edge case)
+  - the ``fuzzy`` transform must produce a stable base word for variant 0 and a
+    variant within ``target_distance`` edits otherwise
+  - the whole transform must be deterministic across runs (benchmarks depend
+    on reproducibility)
+  - the ``fuzzy`` query generator must produce the exact same base words that
+    ``fuzzy`` transform emits as variant 0 (otherwise queries wouldn't match
+    any dataset row)
+  - the ``tag_only`` query generator must rotate through the tag list
+"""
+
+import csv
+import random
+import sys
+from pathlib import Path
+
+# Ensure scripts/ is importable
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import setup_datasets  # noqa: E402
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Compute Levenshtein edit distance between two strings."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        curr = [i]
+        for j, cb in enumerate(b, start=1):
+            curr.append(
+                min(
+                    prev[j] + 1,  # deletion
+                    curr[j - 1] + 1,  # insertion
+                    prev[j - 1] + (ca != cb),  # substitution
+                )
+            )
+        prev = curr
+    return prev[-1]
+
+
+# ---- _apply_fuzzy_edit ------------------------------------------------------
+
+
+class TestApplyFuzzyEdit:
+    def test_insert_increases_length_by_one(self):
+        assert (
+            len(setup_datasets._apply_fuzzy_edit("hello", "insert", random.Random(1)))
+            == 6
+        )
+
+    def test_delete_decreases_length_by_one(self):
+        assert (
+            len(setup_datasets._apply_fuzzy_edit("hello", "delete", random.Random(1)))
+            == 4
+        )
+
+    def test_substitute_preserves_length_and_changes_a_character(self):
+        """Substitute must retry until a different character is produced."""
+        result = setup_datasets._apply_fuzzy_edit(
+            "hello", "substitute", random.Random(1)
+        )
+        assert len(result) == 5
+        assert result != "hello"
+
+    def test_short_word_returned_unchanged(self):
+        """len < 2 must short-circuit and return the input verbatim."""
+        assert setup_datasets._apply_fuzzy_edit("a", "delete", random.Random(1)) == "a"
+
+
+# ---- fuzzy transform -------------------------------------------------------
+
+
+def _fuzzy_transform(**overrides):
+    t = {
+        "type": "fuzzy",
+        "variant_count": 5,
+        "docs_per_variant": 2,
+        "term_count": 10,
+        "min_word_length": 8,
+        "max_word_length": 8,
+        "target_distance": 1,
+    }
+    t.update(overrides)
+    return t
+
+
+class TestFuzzyTransform:
+    def test_all_docs_in_variant_zero_share_the_same_base_word(self):
+        """Every doc that maps to variant 0 of a term must be identical.
+
+        This is the contract that makes the fuzzy query type meaningful.
+        """
+        t = _fuzzy_transform()  # docs_per_variant=2 → doc 1 and doc 2 are v0/term1
+        doc1 = setup_datasets.apply_transforms("", [t], 100, 1, 100)
+        doc2 = setup_datasets.apply_transforms("", [t], 100, 2, 100)
+        assert doc1 == doc2
+
+    def test_variant_one_differs_from_base_by_exactly_target_distance(self):
+        """target_distance=1 must give exactly 1 Levenshtein edit."""
+        t = _fuzzy_transform(target_distance=1)
+        base = setup_datasets.apply_transforms("", [t], 100, 1, 100)
+        variant = setup_datasets.apply_transforms("", [t], 100, 3, 100)
+        assert variant != base
+        assert _levenshtein(base, variant) == 1
+
+    def test_variant_distance_bounded_by_target_distance(self):
+        """target_distance=3 must produce at most 3 edits (edits may compose)."""
+        t = _fuzzy_transform(target_distance=3)
+        base = setup_datasets.apply_transforms("", [t], 100, 1, 100)
+        variant = setup_datasets.apply_transforms("", [t], 100, 3, 100)
+        assert 1 <= _levenshtein(base, variant) <= 3
+
+    def test_transform_is_deterministic_across_invocations(self):
+        """Benchmark reproducibility depends on stable output for same inputs."""
+        t = _fuzzy_transform()
+        for doc_num in [1, 5, 17, 42]:
+            a = setup_datasets.apply_transforms("", [t], 100, doc_num, 100)
+            b = setup_datasets.apply_transforms("", [t], 100, doc_num, 100)
+            assert a == b, f"non-deterministic for doc {doc_num}"
+
+
+# ---- Query generation ------------------------------------------------------
+
+
+class TestGenerateFuzzyQueries:
+    def test_query_terms_equal_dataset_variant_zero(self, tmp_path: Path):
+        """Each query term must equal the base word for that term_id in the dataset.
+
+        If this contract breaks, fuzzy queries will not match anything.
+        """
+        query_config = {
+            "type": "fuzzy",
+            "doc_count": 5,
+            "min_word_length": 8,
+            "max_word_length": 8,
+        }
+        setup_datasets.generate_queries(tmp_path, query_config, "fuzzy_q.csv")
+
+        with open(tmp_path / "fuzzy_q.csv") as f:
+            reader = csv.reader(f)
+            assert next(reader) == ["term"]
+            query_terms = [row[0] for row in reader]
+
+        assert len(query_terms) == 5
+
+        dataset_transform = _fuzzy_transform(
+            variant_count=5, docs_per_variant=1, term_count=5
+        )
+        # docs_per_variant=1, variant_count=5 → doc 1 = term 1 v0,
+        # doc 6 = term 2 v0, doc 11 = term 3 v0, ...
+        for i, expected_term in enumerate(query_terms, start=1):
+            doc_num_for_v0 = (i - 1) * 5 + 1
+            dataset_v0 = setup_datasets.apply_transforms(
+                "", [dataset_transform], 100, doc_num_for_v0, 100
+            )
+            assert dataset_v0 == expected_term
+
+
+class TestGenerateTagOnlyQueries:
+    def test_rotates_through_tag_list_with_category_header(self, tmp_path: Path):
+        query_config = {
+            "type": "tag_only",
+            "doc_count": 7,
+            "tags": ["electronics", "books", "clothing"],
+        }
+        setup_datasets.generate_queries(tmp_path, query_config, "tag_q.csv")
+
+        with open(tmp_path / "tag_q.csv") as f:
+            reader = csv.reader(f)
+            header = next(reader)
+            rows = [row[0] for row in reader]
+
+        assert header == ["category"]
+        assert rows == [
+            "electronics",
+            "books",
+            "clothing",
+            "electronics",
+            "books",
+            "clothing",
+            "electronics",
+        ]

--- a/tests/test_setup_datasets.py
+++ b/tests/test_setup_datasets.py
@@ -207,12 +207,7 @@ class TestVectorHybridQueryAlignment:
     """
 
     def test_every_query_term_appears_in_the_hybrid_dataset(self, tmp_path: Path):
-        try:
-            import numpy as np
-        except ImportError:  # pragma: no cover - numpy is a hard dep
-            import pytest
-
-            pytest.skip("numpy not installed")
+        import numpy as np
 
         dims = 4
         doc_count = 10

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -330,7 +330,11 @@ class ClientRunner:
                 commit_time,
             )
             if result:
-                metric_json.append(result)
+                # Mixed workloads return a list of metrics (one per sub-scenario)
+                if isinstance(result, list):
+                    metric_json.extend(result)
+                else:
+                    metric_json.append(result)
 
         # Finalize and write results
         self._finalize_metrics(metrics_processor, metric_json, profiling_enabled)
@@ -733,7 +737,11 @@ class ClientRunner:
         )
 
     def _expand_scenario_options(self, scenario: dict) -> List[dict]:
-        """Expand scenario with options to create variants."""
+        """Expand scenario with options to create variants.
+
+        For mixed workloads, options are applied to all read sub-scenarios
+        rather than the top-level command.
+        """
         options = scenario.get("options")
 
         # No options: return scenario as-is
@@ -745,7 +753,15 @@ class ClientRunner:
         for flag, suffix in options.items():
             variant = copy.deepcopy(scenario)
             variant["id"] = scenario["id"] + suffix
-            variant["command"] = scenario["command"] + (f" {flag}" if flag else "")
+
+            if variant.get("type") == "mixed":
+                # Mixed: apply option flag to each read sub-scenario
+                for read in variant.get("reads", []):
+                    if flag:
+                        read["command"] = read["command"] + f" {flag}"
+            else:
+                variant["command"] = scenario["command"] + (f" {flag}" if flag else "")
+
             if "description" in variant and flag:
                 variant["description"] += f" + {flag}"
             scenarios.append(variant)
@@ -854,7 +870,20 @@ class ClientRunner:
         warmup_duration = scenario.get("warmup", 0)
         try:
             if warmup_duration > 0:
-                if self._should_use_parallel(scenario):
+                if scenario_type == "mixed":
+                    logging.info(f"Running mixed warmup: {warmup_duration}s")
+                    warmup_scenario = copy.deepcopy(scenario)
+                    warmup_scenario["duration"] = warmup_duration
+                    # Run mixed workload for warmup, discard results
+                    self._run_mixed_workload(
+                        warmup_scenario,
+                        group_id,
+                        config_set,
+                        metrics_processor=None,
+                        warmup_duration=0,
+                        commit_time=commit_time,
+                    )
+                elif self._should_use_parallel(scenario):
                     logging.info(
                         f"Running parallel warmup on {len(self._get_active_ports())} nodes: {warmup_duration}s"
                     )
@@ -889,6 +918,23 @@ class ClientRunner:
                 profiler.start_profiling(
                     profile_id, target_process="valkey-server", target_port=target_port
                 )
+
+            # Handle mixed workload: run concurrent writes + reads
+            if scenario_type == "mixed":
+                logging.info(f"Running mixed workload for scenario {scenario_id}")
+                metrics_list = self._run_mixed_workload(
+                    scenario,
+                    group_id,
+                    config_set,
+                    metrics_processor,
+                    warmup_duration,
+                    commit_time,
+                    group_description=group_description,
+                    scenario_id=scenario_id,
+                )
+                if profiler and scenario_profiling_enabled:
+                    profiler.stop_profiling(profile_id)
+                return metrics_list if metrics_list else None
 
             if self._should_use_parallel(scenario):
                 logging.info(f"Using parallel execution for scenario {scenario_id}")
@@ -986,6 +1032,270 @@ class ClientRunner:
         except Exception as e:
             logging.error(f"Failed to execute setup command '{cmd_str}': {e}")
             raise
+
+    def _normalize_mixed_configs(self, scenario: dict):
+        """Propagate shared parameters from parent scenario to sub-scenarios.
+
+        Writes/reads sub-scenarios inherit ``duration``, ``pipeline``, and
+        ``cluster_execution`` from the parent when not explicitly set.
+        """
+        write_scenarios = scenario.get("writes", [])
+        read_scenarios = scenario.get("reads", [])
+
+        for cfg in write_scenarios + read_scenarios:
+            if "duration" not in cfg and scenario.get("duration") is not None:
+                cfg["duration"] = scenario["duration"]
+            if "pipeline" not in cfg:
+                cfg["pipeline"] = scenario.get("pipeline", 1)
+            if "cluster_execution" not in cfg and scenario.get("cluster_execution"):
+                cfg["cluster_execution"] = scenario["cluster_execution"]
+
+        return write_scenarios, read_scenarios
+
+    def _get_cpu_for_mixed_process(self, process_idx: int) -> Optional[str]:
+        """Allocate ``cores_per_client`` cores to each mixed-workload process.
+
+        Splits the client CPU pool starting from the first configured range so
+        each concurrent process runs on its own cores. Logs a warning if the
+        allocation would extend past the end of the last configured range so
+        the operator knows processes will start overlapping cores.
+        """
+        if not self.client_cpu_ranges:
+            return None
+
+        cpu_alloc = self.config.get("cpu_allocation", {})
+        cores_per_client = cpu_alloc.get("cores_per_client", 1)
+
+        first_range = self.client_cpu_ranges[0]
+        if "-" in first_range:
+            start_core, _ = map(int, first_range.split("-"))
+        else:
+            start_core = int(first_range)
+
+        proc_start = start_core + (process_idx * cores_per_client)
+        proc_end = proc_start + cores_per_client - 1
+
+        # Warn if we've walked off the end of the last configured range.
+        last_range = self.client_cpu_ranges[-1]
+        if "-" in last_range:
+            _, end_core = map(int, last_range.split("-"))
+        else:
+            end_core = int(last_range)
+        if proc_end > end_core:
+            logging.warning(
+                f"Mixed process {process_idx} pinned to cores {proc_start}-{proc_end} "
+                f"which exceeds the client CPU pool ending at core {end_core}. "
+                f"Processes may overlap CPU cores."
+            )
+
+        return f"{proc_start}-{proc_end}" if proc_end > proc_start else str(proc_start)
+
+    def _launch_mixed_process(
+        self, sub_scenario: dict, port: int, process_idx: int, label: str
+    ):
+        """Launch a single benchmark subprocess for a mixed sub-scenario."""
+        cpu = self._get_cpu_for_mixed_process(process_idx)
+        cmd = self._build_benchmark_command(
+            scenario=sub_scenario, port=port, cpu_range=cpu
+        )
+        cmd_str = shlex.join(cmd)
+        logging.info(f"{label} [port {port}]: {cmd_str[:200]}...")
+        return subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=self.valkey_path,
+        )
+
+    def _launch_mixed_processes(
+        self, write_scenarios: List[dict], read_scenarios: List[dict], ports: List[int]
+    ):
+        """Launch all mixed write + read processes across the given ports."""
+        process_idx = 0
+        write_procs = []
+        for write_cfg in write_scenarios:
+            sub = copy.deepcopy(write_cfg)
+            write_id = write_cfg.get("id", "w")
+            for port in ports:
+                proc = self._launch_mixed_process(
+                    sub, port, process_idx, f"write-{write_id}"
+                )
+                write_procs.append((proc, port, write_id))
+                process_idx += 1
+
+        read_procs = []
+        for read_cfg in read_scenarios:
+            sub = copy.deepcopy(read_cfg)
+            read_id = read_cfg.get("id", "r")
+            for port in ports:
+                proc = self._launch_mixed_process(
+                    sub, port, process_idx, f"read-{read_id}"
+                )
+                read_procs.append((proc, port, read_id))
+                process_idx += 1
+
+        return write_procs, read_procs
+
+    def _collect_mixed_results(self, procs: List[tuple], label: str) -> dict:
+        """Wait for mixed workload processes and group results by sub-scenario id."""
+        results_by_id: dict = {}
+        for proc, port, sub_id in procs:
+            stdout, stderr = proc.communicate()
+            if proc.returncode == 0:
+                results_by_id.setdefault(sub_id, []).append((stdout, stderr, port))
+                logging.info(f"{label}-{sub_id} on port {port} completed")
+            else:
+                logging.error(f"{label}-{sub_id} on port {port} failed: {stderr}")
+        return results_by_id
+
+    def _create_mixed_metric(
+        self,
+        row: dict,
+        sub_cfg: dict,
+        parent_scenario: dict,
+        group_id,
+        scenario_id: str,
+        sub_id: str,
+        phase: str,
+        config_set: dict,
+        warmup_duration: int,
+        metrics_processor,
+        group_description: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Build a metrics dict for a single mixed sub-scenario result."""
+        if not metrics_processor:
+            return None
+
+        metrics = metrics_processor.create_metrics(
+            row,
+            sub_cfg["command"],
+            sub_cfg.get("data_size", 100),
+            sub_cfg.get("pipeline", 1),
+            sub_cfg.get("clients", 1),
+            None,
+            warmup_duration,
+            sub_cfg.get("duration") or parent_scenario.get("duration"),
+        )
+        if not metrics:
+            return None
+
+        metrics["status"] = "success"
+        metrics["test_id"] = f"{group_id}_{scenario_id}_{phase}_{sub_id}"
+        metrics["test_phase"] = f"mixed_{phase}"
+        metrics["group"] = group_id
+        metrics["scenario"] = scenario_id
+        metrics["config_set"] = config_set
+        if group_description:
+            metrics["group_description"] = group_description
+        if parent_scenario.get("description"):
+            metrics["scenario_description"] = parent_scenario["description"]
+        if sub_cfg.get("dataset"):
+            metrics["dataset"] = sub_cfg["dataset"]
+        return metrics
+
+    def _run_mixed_workload(
+        self,
+        scenario: dict,
+        group_id,
+        config_set: dict,
+        metrics_processor,
+        warmup_duration: int,
+        commit_time: str,
+        group_description: Optional[str] = None,
+        scenario_id: Optional[str] = None,
+    ) -> Optional[List[dict]]:
+        """Run a mixed workload of concurrent writes + reads.
+
+        Each write and read sub-scenario is launched as its own process on the
+        appropriate ports and CPU range. Results are collected and reported as
+        one metric per sub-scenario id.
+        """
+        write_scenarios, read_scenarios = self._normalize_mixed_configs(scenario)
+
+        if not write_scenarios and not read_scenarios:
+            logging.warning(
+                f"Mixed scenario {scenario.get('id')} has no writes or reads"
+            )
+            return None
+
+        # Determine target ports based on cluster execution mode
+        if scenario.get("cluster_execution") == "single" or not self._is_cme():
+            ports = [self._get_active_ports()[0]]
+        else:
+            ports = self._get_active_ports()
+
+        total_writes = sum(w.get("clients", 1) for w in write_scenarios)
+        total_reads = sum(r.get("clients", 1) for r in read_scenarios)
+        logging.info(
+            f"Mixed workload: {total_writes} write clients + {total_reads} read clients "
+            f"across {len(ports)} node(s)"
+        )
+
+        # Launch all processes concurrently
+        write_procs, read_procs = self._launch_mixed_processes(
+            write_scenarios, read_scenarios, ports
+        )
+
+        # Collect results grouped by sub-scenario id
+        write_results = self._collect_mixed_results(write_procs, "write")
+        read_results = self._collect_mixed_results(read_procs, "read")
+
+        # If metrics_processor is None (warmup mode), just drain and exit
+        if metrics_processor is None:
+            return None
+
+        sid = scenario_id or scenario.get("id", "unknown")
+        metrics_list: List[dict] = []
+
+        for write_cfg in write_scenarios:
+            wid = write_cfg.get("id", "w")
+            if wid not in write_results or not write_results[wid]:
+                continue
+            row = self._aggregate_parallel_results(
+                write_results[wid], {"command": write_cfg["command"]}
+            )
+            m = self._create_mixed_metric(
+                row,
+                write_cfg,
+                scenario,
+                group_id,
+                sid,
+                wid,
+                "write",
+                config_set,
+                warmup_duration,
+                metrics_processor,
+                group_description,
+            )
+            if m:
+                metrics_list.append(m)
+
+        for read_cfg in read_scenarios:
+            rid = read_cfg.get("id", "r")
+            if rid not in read_results or not read_results[rid]:
+                continue
+            row = self._aggregate_parallel_results(
+                read_results[rid], {"command": read_cfg["command"]}
+            )
+            m = self._create_mixed_metric(
+                row,
+                read_cfg,
+                scenario,
+                group_id,
+                sid,
+                rid,
+                "read",
+                config_set,
+                warmup_duration,
+                metrics_processor,
+                group_description,
+            )
+            if m:
+                metrics_list.append(m)
+
+        logging.info(f"Mixed workload produced {len(metrics_list)} metric entries")
+        return metrics_list if metrics_list else None
 
     def _run_parallel_search(
         self,

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -1225,8 +1225,11 @@ class ClientRunner:
         else:
             ports = self._get_active_ports()
 
-        total_writes = sum(w.get("clients", 1) for w in write_scenarios)
-        total_reads = sum(r.get("clients", 1) for r in read_scenarios)
+        # Each sub-scenario is launched once per port (i.e. once per node in
+        # CME parallel mode), so the real client count is `clients * len(ports)`
+        # per sub-scenario.
+        total_writes = sum(w.get("clients", 1) for w in write_scenarios) * len(ports)
+        total_reads = sum(r.get("clients", 1) for r in read_scenarios) * len(ports)
         logging.info(
             f"Mixed workload: {total_writes} write clients + {total_reads} read clients "
             f"across {len(ports)} node(s)"


### PR DESCRIPTION
Add two capabilities for scenario-based (test_groups) configs:

* type: mixed - spawn concurrent write and read sub-scenarios in the same test window. Each sub-scenario runs as its own valkey-benchmark process on its own CPU range and produces its own metric entry. options on a mixed scenario apply to each read sub-scenario.

* fuzzy transform + fuzzy/tag_only query types - deterministic base words per term_id with target_distance Levenshtein-edit variants. Query generator uses the same seed so every query has known matches in the dataset. Fixes a latent 'import random' shadowing bug in the existing numeric_range / tag_list branches.

Also adds README docs and focused unit tests for both features.