### PR TITLE
Add multi-run support for module benchmarks

### DIFF
--- a/.github/workflows/search_benchmark.yml
+++ b/.github/workflows/search_benchmark.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: ""
         type: string
+      num_runs:
+        description: "Number of times to repeat each read scenario (default: 3)"
+        required: false
+        default: "3"
+        type: string
       skip_profiling:
         description: "Check for skip profiling"
         default: true
@@ -82,6 +87,7 @@ jobs:
       CONFIG_FILE: "${{ github.workspace }}/valkey-perf-benchmark/configs/${{ inputs.config_json || 'fts-benchmarks-shortened-arm.json' }}"
       # Run parameters
       MAX_MODULE_COMMITS: ${{ inputs.max_module_commits || '1' }}
+      NUM_RUNS: ${{ inputs.num_runs || '3' }}
       CORE_COMMIT_INPUT: ${{ inputs.core_commit || '' }}
       MODULE_COMMITS_INPUT: ${{ inputs.module_commits || '' }}
       CLUSTER_MODE: ${{ inputs.cluster_mode || '' }}
@@ -341,6 +347,7 @@ jobs:
               --module-path "$MODULE_PATH/.build-release/libsearch.so" \
               --module-commit "$MODULE_SHA" \
               --module-commit-timestamp "$MODULE_TS" \
+              --runs "$NUM_RUNS" \
               ${CLUSTER_MODE:+--cluster-mode-filter "$CLUSTER_MODE"} \
               ${SKIP_CONFIG_SET:+--skip-config-set} \
               ${SKIP_PROFILING:+--skip-profiling} \

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -396,7 +396,10 @@ class ClientRunner:
                 }
 
     def _iterate_test_groups_scenarios(self):
-        """Generate scenarios from test_groups configuration."""
+        """Generate scenarios from test_groups configuration.
+
+        When ``self.runs > 1``, the entire group is repeated multiple times.
+        """
         groups_to_run = self.config.get("groups_to_run")
         scenario_filter = self.config.get("scenario_filter")
 
@@ -411,29 +414,36 @@ class ClientRunner:
                 )
                 continue
 
-            logging.info(f"=== Group {group_id}: {group_description or ''} ===")
+            for run_num in range(self.runs):
+                if self.runs > 1:
+                    logging.info(
+                        f"=== Group {group_id}: {group_description or ''} "
+                        f"(run {run_num + 1}/{self.runs}) ==="
+                    )
+                else:
+                    logging.info(f"=== Group {group_id}: {group_description or ''} ===")
 
-            for scenario in test_group.get("scenarios", []):
-                # Expand scenario options (e.g., with/without flags)
-                for expanded_scenario in self._expand_scenario_options(scenario):
-                    # Skip filtered scenarios
-                    if (
-                        scenario_filter
-                        and expanded_scenario.get("id") not in scenario_filter
-                    ):
-                        logging.info(
-                            f"Skipping scenario {expanded_scenario.get('id')} (filtered)"
-                        )
-                        continue
+                for scenario in test_group.get("scenarios", []):
+                    # Expand scenario options (e.g., with/without flags)
+                    for expanded_scenario in self._expand_scenario_options(scenario):
+                        # Skip filtered scenarios
+                        if (
+                            scenario_filter
+                            and expanded_scenario.get("id") not in scenario_filter
+                        ):
+                            logging.info(
+                                f"Skipping scenario {expanded_scenario.get('id')} (filtered)"
+                            )
+                            continue
 
-                    yield {
-                        "format": "test_groups",
-                        "scenario": expanded_scenario,
-                        "group_id": group_id,
-                        "group_description": group_description,
-                        "config_set": self.current_config_set,
-                        "config_suffix": self.config_suffix,
-                    }
+                        yield {
+                            "format": "test_groups",
+                            "scenario": expanded_scenario,
+                            "group_id": group_id,
+                            "group_description": group_description,
+                            "config_set": self.current_config_set,
+                            "config_suffix": self.config_suffix,
+                        }
 
     def _execute_scenario(
         self, scenario_data, profiler, metrics_processor, profiling_enabled, commit_time


### PR DESCRIPTION
**Description:**

The `--runs` flag only worked for core (simple format) benchmarks. Module benchmarks using `test_groups` always ran once regardless of the flag.

This adds multi-run support by looping the entire group N times. Each iteration re-executes the write scenario (flush + data reload) followed by all read scenarios, matching the core's design where multiple runs simply produce additional metrics entries that downstream tools average.

**Changes:**
- `valkey_benchmark.py`: Loop groups `self.runs` times in `_iterate_test_groups_scenarios()`
- `search_benchmark.yml`: Add `num_runs` input, wire `--runs` to benchmark invocation, default to 3 for scheduled runs
