### PR TITLE
Fix Wikipedia dataset generation for XML-only configs

### DIFF
--- a/scripts/setup_datasets.py
+++ b/scripts/setup_datasets.py
@@ -128,7 +128,16 @@ def download_wikipedia(output_dir: Path) -> Path:
     logging.info(f"Downloading Wikipedia (~20GB, 30-60 min)...")
 
     try:
-        urllib.request.urlretrieve(url, compressed)
+        req = urllib.request.Request(
+            url,
+            headers={"User-Agent": "valkey-perf-benchmark/1.0 (benchmark dataset download)"},
+        )
+        with urllib.request.urlopen(req) as response, open(compressed, "wb") as out_file:
+            while True:
+                chunk = response.read(1024 * 1024)  # 1MB chunks
+                if not chunk:
+                    break
+                out_file.write(chunk)
         subprocess.run(["bunzip2", "-k", str(compressed)], check=True)
         return extracted
     except Exception as e:

--- a/scripts/setup_datasets.py
+++ b/scripts/setup_datasets.py
@@ -119,7 +119,9 @@ def download_wikipedia(output_dir: Path) -> Path:
         if result.returncode == 0:
             return extracted
         else:
-            logging.warning(f"Extraction failed (possibly partial download). Removing {compressed.name} and re-downloading...")
+            logging.warning(
+                f"Extraction failed (possibly partial download). Removing {compressed.name} and re-downloading..."
+            )
             compressed.unlink()
 
     url = (
@@ -130,9 +132,14 @@ def download_wikipedia(output_dir: Path) -> Path:
     try:
         req = urllib.request.Request(
             url,
-            headers={"User-Agent": "valkey-perf-benchmark/1.0 (benchmark dataset download)"},
+            headers={
+                "User-Agent": "valkey-perf-benchmark/1.0 (benchmark dataset download)"
+            },
         )
-        with urllib.request.urlopen(req) as response, open(compressed, "wb") as out_file:
+        with (
+            urllib.request.urlopen(req) as response,
+            open(compressed, "wb") as out_file,
+        ):
             while True:
                 chunk = response.read(1024 * 1024)  # 1MB chunks
                 if not chunk:
@@ -815,7 +822,9 @@ def main():
     # Also check if any CSV file needs Wikipedia (hybrid data with wikipedia transforms)
     if not needs_wiki:
         for filename in files_to_gen:
-            if filename in dataset_configs and (filename.endswith(".csv") or filename.endswith(".xml")):
+            if filename in dataset_configs and (
+                filename.endswith(".csv") or filename.endswith(".xml")
+            ):
                 field_configs = build_field_configs(dataset_configs[filename])
                 needs_wiki = any(
                     any(

--- a/scripts/setup_datasets.py
+++ b/scripts/setup_datasets.py
@@ -815,7 +815,7 @@ def main():
     # Also check if any CSV file needs Wikipedia (hybrid data with wikipedia transforms)
     if not needs_wiki:
         for filename in files_to_gen:
-            if filename in dataset_configs and filename.endswith(".csv"):
+            if filename in dataset_configs and (filename.endswith(".csv") or filename.endswith(".xml")):
                 field_configs = build_field_configs(dataset_configs[filename])
                 needs_wiki = any(
                     any(

--- a/scripts/setup_datasets.py
+++ b/scripts/setup_datasets.py
@@ -115,8 +115,12 @@ def download_wikipedia(output_dir: Path) -> Path:
 
     if compressed.exists():
         logging.info(f"Extracting {compressed.name}...")
-        subprocess.run(["bunzip2", "-k", str(compressed)], check=True)
-        return extracted
+        result = subprocess.run(["bunzip2", "-k", str(compressed)])
+        if result.returncode == 0:
+            return extracted
+        else:
+            logging.warning(f"Extraction failed (possibly partial download). Removing {compressed.name} and re-downloading...")
+            compressed.unlink()
 
     url = (
         "https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2"


### PR DESCRIPTION

**Description:**

Fixes dataset generation failures when using configs (like `fts-benchmarks-shortened-arm.json`) that reference Wikipedia XML datasets but don't have any CSV files with wikipedia transforms.

**Problem:**
- The `needs_wiki` detection only checked `.csv` files for `"type": "wikipedia"` transforms, missing `.xml` dataset entries entirely. This caused `wiki_1m_1field_100tok.xml` to silently never be generated.
- `urllib.request.urlretrieve` no longer works for Wikimedia downloads — they now require a proper User-Agent header and return 403 Forbidden without one.
- If a previous download was interrupted (partial `.bz2` file), the next run would attempt to decompress the corrupt file and crash with no recovery path.

**Changes:**
1. **XML detection** — Extend `needs_wiki` check to also inspect `.xml` file configs for wikipedia transforms
2. **User-Agent header** — Replace `urlretrieve` with a proper HTTP request that includes a User-Agent string (required by Wikimedia's access policy)
3. **Partial download recovery** — If `bunzip2` fails on a corrupt/partial `.bz2`, delete it and re-download instead of crashing