### PR TITLE
Add module benchmark support to comparison tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ python utils/compare_benchmark_results.py --baseline results/commit1/metrics.jso
   - RPS-focused filtering for integration purposes
 - **Metrics Filtering**: Supports filtering by metric type (all, rps, latency)
 - **Standardized Output**: Generates markdown reports with statistical information including CV
+- **Module Benchmark Support**: Uses the module commit as the version identifier and reports the underlying core engine commit (see below)
+
+### Module Benchmark Comparisons
+
+When comparing module benchmarks (e.g. `valkey-search`), each result record carries both a `module_commit` (the module build under test) and a `commit` (the core Valkey engine it ran against). The comparison tool handles these as follows:
+
+- **Version identifier**: If `module_commit` is present it is used as the version shown in the report title, table headers, and graph legends. Otherwise the tool falls back to `commit`, then to the run timestamp.
+- **Core commit line**: For module comparisons the report adds a `**Core commit:**` line so the core engine version is visible alongside the module version:
+  - `**Core commit:** <sha>` when both sides ran against the same core commit
+  - `**Core commit:** <baseline-sha> (baseline) → <new-sha> (new)` when they differ
 
 ### Statistical Display Format
 

--- a/tests/test_compare_benchmark.py
+++ b/tests/test_compare_benchmark.py
@@ -286,8 +286,6 @@ class TestDiscoverConfigKeys:
         assert "module_commit" not in keys
 
     def test_test_id_sorted_first(self):
-        # test_id should sort before other keys for natural test ordering,
-        # even when other keys alphabetically precede it.
         data = [{"arch": "x86", "clients": 100, "test_id": "1_get"}]
         keys = discover_config_keys(data)
         assert keys[0] == "test_id"

--- a/tests/test_compare_benchmark.py
+++ b/tests/test_compare_benchmark.py
@@ -197,6 +197,35 @@ class TestAverageMultipleRuns:
     def test_empty_data(self):
         assert average_multiple_runs([]) == []
 
+    def test_preserves_module_commit(self):
+        data = [
+            {
+                "command": "GET",
+                "pipeline": 1,
+                "data_size": 64,
+                "rps": 100000.0,
+                "avg_latency_ms": 1.0,
+                "p50_latency_ms": 0.8,
+                "p95_latency_ms": 1.5,
+                "p99_latency_ms": 2.0,
+                "module_commit": "mod12345",
+            },
+            {
+                "command": "GET",
+                "pipeline": 1,
+                "data_size": 64,
+                "rps": 200000.0,
+                "avg_latency_ms": 0.5,
+                "p50_latency_ms": 0.4,
+                "p95_latency_ms": 0.8,
+                "p99_latency_ms": 1.0,
+                "module_commit": "mod12345",
+            },
+        ]
+        result = average_multiple_runs(data)
+        assert len(result) == 1
+        assert result[0]["module_commit"] == "mod12345"
+
     def test_different_configs_not_merged(self):
         data = [
             {
@@ -240,6 +269,7 @@ class TestDiscoverConfigKeys:
                 "p99_latency_ms": 1.2,
                 "timestamp": "2024-01-01",
                 "commit": "abc123",
+                "module_commit": "def456",
             }
         ]
         keys = discover_config_keys(data)
@@ -253,6 +283,14 @@ class TestDiscoverConfigKeys:
         assert "p99_latency_ms" not in keys
         assert "timestamp" not in keys
         assert "commit" not in keys
+        assert "module_commit" not in keys
+
+    def test_test_id_sorted_first(self):
+        # test_id should sort before other keys for natural test ordering,
+        # even when other keys alphabetically precede it.
+        data = [{"arch": "x86", "clients": 100, "test_id": "1_get"}]
+        keys = discover_config_keys(data)
+        assert keys[0] == "test_id"
 
     def test_returns_sorted_keys(self):
         data = [{"zebra": "z", "alpha": "a", "middle": "m"}]
@@ -382,6 +420,18 @@ class TestExtractVersionIdentifier:
     def test_no_commit_no_timestamp_returns_unknown(self):
         data = [{"command": "GET"}]
         assert extract_version_identifier(data) == "Unknown"
+
+    def test_module_commit_short_returned_as_is(self):
+        data = [{"module_commit": "mod12345"}]
+        assert extract_version_identifier(data) == "mod12345"
+
+    def test_module_commit_long_truncated_to_8(self):
+        data = [{"module_commit": "abcdef1234567890abcdef"}]
+        assert extract_version_identifier(data) == "abcdef12"
+
+    def test_module_commit_prioritized_over_commit(self):
+        data = [{"module_commit": "mod12345", "commit": "core6789"}]
+        assert extract_version_identifier(data) == "mod12345"
 
 
 # --- create_config_signature ---

--- a/utils/compare_benchmark_results.py
+++ b/utils/compare_benchmark_results.py
@@ -222,6 +222,7 @@ def discover_config_keys(data: List[Dict[str, Any]]) -> List[str]:
         "timestamp",
         "commit",
         "module_commit",
+        "module_commit_timestamp",
         "repository",
         "run_count",
         # Performance metrics
@@ -465,7 +466,10 @@ def create_config_sort_key(config_tuple: Tuple) -> Tuple[str, ...]:
     """
     Create a sorting key for configuration tuples that handles None values and mixed types.
 
-    Converts all values to strings for consistent comparison, with None values sorting first.
+    Groups by test scenario first (test_id is hoisted to the front of the
+    config keys). Converts all values to strings for consistent comparison,
+    with None values sorting first. Note: sorting is lexicographic, so numeric
+    values embedded in strings sort as text (e.g. "10_get" before "2_get").
     """
 
     def normalize_value(value):
@@ -989,7 +993,8 @@ def format_comparison_report(
     new_version: str,
     baseline_repo: Optional[str] = None,
     new_repo: Optional[str] = None,
-    core_commit: Optional[str] = None,
+    core_commit_baseline: Optional[str] = None,
+    core_commit_new: Optional[str] = None,
 ) -> str:
     """
     Format the comparison data as a markdown report.
@@ -1152,8 +1157,17 @@ def format_comparison_report(
         report_lines.append("**Configuration:**")
         for key in sorted(common_config.keys()):
             report_lines.append(f"- {key}: {common_config[key]}")
-        if core_commit:
-            report_lines.append(f"- core_commit: {core_commit}")
+        report_lines.append("")
+
+    # Add core commit metadata
+    if core_commit_baseline or core_commit_new:
+        if core_commit_baseline == core_commit_new:
+            report_lines.append(f"**Core commit:** {core_commit_baseline}")
+        else:
+            report_lines.append(
+                f"**Core commit:** {core_commit_baseline} (baseline) → "
+                f"{core_commit_new} (new)"
+            )
         report_lines.append("")
 
     # Add legend
@@ -1939,9 +1953,12 @@ def main():
 
     # Format the comparison report
     # Extract core commit if module_commit is used as the version identifier
-    core_commit = None
+    core_commit_baseline = None
+    core_commit_new = None
     if baseline_data and baseline_data[0].get("module_commit"):
-        core_commit = baseline_data[0].get("commit")
+        core_commit_baseline = baseline_data[0].get("commit")
+    if new_data and new_data[0].get("module_commit"):
+        core_commit_new = new_data[0].get("commit")
 
     comparison_table = format_comparison_report(
         config_groups,
@@ -1949,7 +1966,8 @@ def main():
         new_version,
         baseline_repo,
         new_repo,
-        core_commit=core_commit,
+        core_commit_baseline=core_commit_baseline,
+        core_commit_new=core_commit_new,
     )
 
     # Create final report with metadata

--- a/utils/compare_benchmark_results.py
+++ b/utils/compare_benchmark_results.py
@@ -525,8 +525,6 @@ def extract_version_with_repo(data: List[Dict[str, Any]]) -> Tuple[str, Optional
     repository = None
 
     if data:
-        # If module_commit was used as version, use repository field
-        # (which typically contains the module repo for module benchmarks)
         repository = data[0].get("repository")
 
     return version, repository

--- a/utils/compare_benchmark_results.py
+++ b/utils/compare_benchmark_results.py
@@ -221,6 +221,7 @@ def discover_config_keys(data: List[Dict[str, Any]]) -> List[str]:
     excluded_fields = {
         "timestamp",
         "commit",
+        "module_commit",
         "repository",
         "run_count",
         # Performance metrics
@@ -284,7 +285,12 @@ def discover_config_keys(data: List[Dict[str, Any]]) -> List[str]:
                 if isinstance(value, (str, int, float, bool, type(None))):
                     config_keys.add(key)
 
-    return sorted(config_keys)
+    # Sort with test_id first (if present) for natural test ordering
+    sorted_keys = sorted(config_keys)
+    if "test_id" in sorted_keys:
+        sorted_keys.remove("test_id")
+        sorted_keys.insert(0, "test_id")
+    return sorted_keys
 
 
 def create_config_signature(item: Dict[str, Any], config_keys: List[str]) -> Tuple:
@@ -429,6 +435,13 @@ def average_multiple_runs(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                     0
                 ]  # Use first commit (should be same for all runs)
 
+            # Preserve module_commit information from any run
+            module_commits = [
+                run.get("module_commit") for run in runs if run.get("module_commit")
+            ]
+            if module_commits:
+                averaged_item["module_commit"] = module_commits[0]
+
             # Preserve repository information from any run
             repositories = [
                 run.get("repository") for run in runs if run.get("repository")
@@ -465,14 +478,20 @@ def extract_version_identifier(data: List[Dict[str, Any]]) -> str:
     """
     Extract a version identifier from benchmark data.
 
-    Prioritizes commit hash, falls back to a short timestamp format, or returns "Unknown".
+    Prioritizes module_commit (for module benchmarks), then commit hash,
+    falls back to a short timestamp format, or returns "Unknown".
     """
     if not data:
         return "Unknown"
 
     first_item = data[0]
 
-    # Try commit hash first
+    # Try module_commit first (module benchmarks)
+    module_commit = first_item.get("module_commit")
+    if module_commit:
+        return module_commit if len(module_commit) <= 12 else module_commit[:8]
+
+    # Try commit hash (core benchmarks)
     commit = first_item.get("commit")
     if commit:
         # Return short hash if already short, otherwise truncate to 8 characters
@@ -506,6 +525,8 @@ def extract_version_with_repo(data: List[Dict[str, Any]]) -> Tuple[str, Optional
     repository = None
 
     if data:
+        # If module_commit was used as version, use repository field
+        # (which typically contains the module repo for module benchmarks)
         repository = data[0].get("repository")
 
     return version, repository

--- a/utils/compare_benchmark_results.py
+++ b/utils/compare_benchmark_results.py
@@ -989,6 +989,7 @@ def format_comparison_report(
     new_version: str,
     baseline_repo: Optional[str] = None,
     new_repo: Optional[str] = None,
+    core_commit: Optional[str] = None,
 ) -> str:
     """
     Format the comparison data as a markdown report.
@@ -1151,6 +1152,8 @@ def format_comparison_report(
         report_lines.append("**Configuration:**")
         for key in sorted(common_config.keys()):
             report_lines.append(f"- {key}: {common_config[key]}")
+        if core_commit:
+            report_lines.append(f"- core_commit: {core_commit}")
         report_lines.append("")
 
     # Add legend
@@ -1935,8 +1938,14 @@ def main():
                 print(f"  - {file_path}")
 
     # Format the comparison report
+    # Extract core commit if module_commit is used as the version identifier
+    core_commit = None
+    if baseline_data and baseline_data[0].get("module_commit"):
+        core_commit = baseline_data[0].get("commit")
+
     comparison_table = format_comparison_report(
-        config_groups, baseline_version, new_version, baseline_repo, new_repo
+        config_groups, baseline_version, new_version, baseline_repo, new_repo,
+        core_commit=core_commit,
     )
 
     # Create final report with metadata

--- a/utils/compare_benchmark_results.py
+++ b/utils/compare_benchmark_results.py
@@ -1944,7 +1944,11 @@ def main():
         core_commit = baseline_data[0].get("commit")
 
     comparison_table = format_comparison_report(
-        config_groups, baseline_version, new_version, baseline_repo, new_repo,
+        config_groups,
+        baseline_version,
+        new_version,
+        baseline_repo,
+        new_repo,
         core_commit=core_commit,
     )
 


### PR DESCRIPTION
## Add module benchmark support to comparison tool

### Summary
Extends `utils/compare_benchmark_results.py` to correctly handle **module benchmarks** (e.g. valkey-search) in addition to core Valkey benchmarks. 

All changes are **additive and guarded by field presence**, so core benchmark output is unaffected (core/simple-format configs never emit `module_commit` or `test_id`).

### Changes

**`extract_version_identifier`** — now prioritizes `module_commit` over `commit` when deriving the version label. Module benchmarks (which carry `module_commit` and often no core `commit`) previously fell through to a timestamp or `"Unknown"`; they now show the module SHA in report titles and graph legends.

**`discover_config_keys`**
- Excludes `module_commit` from config keys (it's metadata, not a test parameter) — mirrors the existing `commit`/`timestamp` exclusions.
- Sorts `test_id` first so test scenarios list in natural order. No-op for core benchmarks (no `test_id` present).

**`average_multiple_runs`** — preserves `module_commit` across averaged runs, mirroring the existing `commit` preservation.

**`format_comparison_report`** — adds an optional `core_commit` line to the Configuration section. When a comparison is keyed on `module_commit`, `main()` surfaces the underlying core Valkey `commit` so both the module version and the core version it ran against are visible in the report. Module-only by design (only populated when `module_commit` is present).

### Tests
Added to `tests/test_compare_benchmark.py`, following the existing `commit`/`timestamp` test patterns:
- `discover_config_keys`: `module_commit` excluded; `test_id` sorted first
- `extract_version_identifier`: `module_commit` short/truncated, and prioritized over `commit`
- `average_multiple_runs`: `module_commit` preserved across runs