### PR TITLE
Extend write duration to 120s and simplify cluster config

### DIFF
--- a/.github/workflows/search_benchmark.yml
+++ b/.github/workflows/search_benchmark.yml
@@ -48,9 +48,9 @@ on:
           - "true"
           - "false"
       timeout_minutes:
-        description: "Job timeout in minutes (default 300)"
+        description: "Job timeout in minutes (default 600)"
         required: false
-        default: "300"
+        default: "600"
         type: string
   schedule:
     - cron: "0 */4 * * *"
@@ -99,7 +99,7 @@ jobs:
       SKIP_CONFIG_SET: ${{ inputs.skip_config_set && '1' || '' }}
       SKIP_PROFILING: ${{ (github.event_name == 'schedule' || inputs.skip_profiling) && '1' || '' }}
     runs-on: [self-hosted, valkey-search-arm]
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes || '300') }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes || '600') }}
     steps:
       - name: Ensure git is installed
         run: command -v git || sudo dnf install -y git

--- a/configs/fts-benchmarks-shortened-arm.json
+++ b/configs/fts-benchmarks-shortened-arm.json
@@ -152,7 +152,7 @@
             "xml_root_element": "doc",
             "maxdocs": 100000,
             "clients": 1000,
-            "duration": 90,
+            "duration": 120,
             "sequential": true,
             "command": "HSET rd0-{tag}:__rand_int__ field1 \"__field:field1__\""
           },
@@ -217,7 +217,7 @@
             "dataset": "datasets/hybrid_data_100k.csv",
             "maxdocs": 100000,
             "clients": 1000,
-            "duration": 90,
+            "duration": 120,
             "sequential": true,
             "command": "HSET rd0-{tag}:__rand_int__ title \"__field:title__\" price \"__field:price__\" category \"__field:category__\""
           },
@@ -337,7 +337,7 @@
             "dataset": "datasets/vector_hybrid_100k.npy",
             "maxdocs": 100000,
             "clients": 1000,
-            "duration": 90,
+            "duration": 120,
             "sequential": true,
             "command": "HSET rd0-{tag}:__rand_int__ title \"__field:title__\" price \"__field:price__\" category \"__field:category__\" embedding \"__field:embedding__\""
           },
@@ -387,7 +387,7 @@
             "dataset": "datasets/vector_hybrid_100k.npy",
             "maxdocs": 100000,
             "clients": 1000,
-            "duration": 90,
+            "duration": 120,
             "sequential": true,
             "command": "HSET rd0-{tag}:__rand_int__ title \"__field:title__\" price \"__field:price__\" category \"__field:category__\" embedding \"__field:embedding__\"",
             "profiling": {
@@ -590,7 +590,7 @@
             "dataset": "datasets/hybrid_data_100k.csv",
             "maxdocs": 100000,
             "clients": 1000,
-            "duration": 90,
+            "duration": 120,
             "sequential": true,
             "command": "HSET rd0-{tag}:__rand_int__ title \"__field:title__\" price \"__field:price__\" category \"__field:category__\""
           },
@@ -605,8 +605,7 @@
             "warmup": 30,
             "command": "FT.SEARCH rd0 \"__field:term1__ @price:[100 500]\"",
             "options": {
-              "": "",
-              "NOCONTENT": "_nocontent"
+              "": ""
             }
           },
           {
@@ -653,11 +652,6 @@
       }
     ],
     "config_sets": [
-      {
-        "search.reader-threads": 1,
-        "search.writer-threads": 1,
-        "search.async-fanout-threshold": 4
-      },
       {
         "search.reader-threads": 8,
         "search.writer-threads": 8,


### PR DESCRIPTION
1. Workflow timeout: 300 → 600 minutes

2. Write scenario durations: 90 → 120 seconds (all 5 writes)

3. Cluster canary: removed NOCONTENT option from scenario 1b

4. Cluster canary: removed single-threaded config_set

