### PR TITLE
Add module commit info to mixed test and update duration display and add branch option

### DIFF
--- a/.github/workflows/search_benchmark.yml
+++ b/.github/workflows/search_benchmark.yml
@@ -51,6 +51,10 @@ on:
         description: "Job timeout in minutes (default 600)"
         required: false
         default: "600"
+      module_branch:
+        description: "Module branch to benchmark (default: main)"
+        required: false
+        default: "main"
         type: string
   schedule:
     - cron: "0 */4 * * *"
@@ -76,7 +80,7 @@ jobs:
       # Module configuration
       MODULE_NAME: "search"
       MODULE_GITHUB_REPO: "valkey-io/valkey-search"
-      MODULE_BRANCH: "main"
+      MODULE_BRANCH: ${{ inputs.module_branch || 'main' }}
       MODULE_DIR: "valkey-search"
       MODULE_PATH: "${{ github.workspace }}/valkey-search"
       # Core configuration

--- a/process_metrics.py
+++ b/process_metrics.py
@@ -109,12 +109,12 @@ class MetricsProcessor:
             }
 
             # Add requests or duration based on benchmark mode
-            if requests is not None:
-                metrics_dict["requests"] = int(requests)
-                metrics_dict["benchmark_mode"] = "requests"
-            elif duration is not None:
+            if duration is not None:
                 metrics_dict["duration"] = int(duration)
                 metrics_dict["benchmark_mode"] = "duration"
+            elif requests is not None:
+                metrics_dict["requests"] = int(requests)
+                metrics_dict["benchmark_mode"] = "requests"
             else:
                 logging.warning("Neither requests nor duration specified")
                 metrics_dict["benchmark_mode"] = "unknown"

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -1216,6 +1216,10 @@ class ClientRunner:
             metrics["scenario_description"] = parent_scenario["description"]
         if self.config_name:
             metrics["config_name"] = self.config_name
+        if self.module_commit:
+            metrics["module_commit"] = self.module_commit
+        if self.module_commit_timestamp:
+            metrics["module_commit_timestamp"] = self.module_commit_timestamp
         if sub_cfg.get("dataset"):
             metrics["dataset"] = sub_cfg["dataset"]
         return metrics


### PR DESCRIPTION
1. mixed test used its own function and previously did not pass in `module_commit `and `module_commit_timestamp`
2. In the `valkey_benchmark.py`, `duration` take precedence of `requests`(`duration` will be used if provided, regardless of `request` provided). However, in the metrics output logic, `requests` take precedence of `duration` (`request` is outputted regardless of `duration` provided). 
3. Add user input module branch option. 