### PR TITLE
Add num_run profiling support

### DIFF
--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -443,6 +443,7 @@ class ClientRunner:
                             "group_description": group_description,
                             "config_set": self.current_config_set,
                             "config_suffix": self.config_suffix,
+                            "run_num": run_num,
                         }
 
     def _execute_scenario(
@@ -566,6 +567,7 @@ class ClientRunner:
             data["config_set"],
             data["config_suffix"],
             data.get("group_description"),
+            data.get("run_num", 0),
         )
 
     def _generate_combinations(self) -> List[tuple]:
@@ -860,6 +862,7 @@ class ClientRunner:
         config_set,
         config_suffix,
         group_description=None,
+        run_num=0,
     ):
         """Run a single scenario."""
         scenario_type = scenario.get("type", "test")
@@ -881,7 +884,7 @@ class ClientRunner:
             effective_profiling = self.current_profiling_set
 
         scenario_profiling_enabled = effective_profiling.get("enabled", False)
-        profile_id = f"group{group_id}_{scenario_type}_{scenario_id}_{config_suffix}"
+        profile_id = f"group{group_id}_{scenario_type}_{scenario_id}_{config_suffix}_run{run_num}"
 
         warmup_duration = scenario.get("warmup", 0)
         try:


### PR DESCRIPTION
Add num_run in the profiling result naming. So multiple run produces distinct profiling naming. 