### PR TITLE
Add PostgreSQL integration tests for commit tracking and metrics push

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -86,6 +86,7 @@ def pg_table(pg_conn):
         cur.execute(f"DROP TABLE IF EXISTS {table_name}")
     pg_conn.commit()
 
+
 # Make project root importable for all integration tests
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,15 @@
-"""Fixtures and utilities for integration tests."""
+"""Fixtures and utilities for integration tests.
+
+PostgreSQL fixtures (pg_conn, requires_postgres) expect a local Postgres instance.
+See test_postgres_track_commits.py or test_postgres_push_metrics.py for Docker setup.
+
+Connection defaults can be overridden via environment variables:
+    TEST_PG_HOST (default: localhost)
+    TEST_PG_PORT (default: 5433)
+    TEST_PG_USER (default: testuser)
+    TEST_PG_PASSWORD (default: valkey-search)
+    TEST_PG_DATABASE (default: testdb)
+"""
 
 import json
 import os
@@ -11,6 +22,69 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import pytest
+
+# ---------------------------------------------------------------------------
+# PostgreSQL fixtures (for DB integration tests)
+# ---------------------------------------------------------------------------
+
+PG_HOST = os.environ.get("TEST_PG_HOST", "localhost")
+PG_PORT = int(os.environ.get("TEST_PG_PORT", "5433"))
+PG_USER = os.environ.get("TEST_PG_USER", "testuser")
+PG_PASSWORD = os.environ.get("TEST_PG_PASSWORD", "valkey-search")
+PG_DATABASE = os.environ.get("TEST_PG_DATABASE", "testdb")
+
+
+def _pg_available() -> bool:
+    """Check if test PostgreSQL is reachable."""
+    try:
+        import psycopg2
+
+        conn = psycopg2.connect(
+            host=PG_HOST,
+            port=PG_PORT,
+            user=PG_USER,
+            password=PG_PASSWORD,
+            database=PG_DATABASE,
+            connect_timeout=3,
+        )
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+requires_postgres = pytest.mark.skipif(
+    not _pg_available(),
+    reason=f"PostgreSQL not available at {PG_HOST}:{PG_PORT} "
+    "(set TEST_PG_* env vars or see integration README).",
+)
+
+
+@pytest.fixture
+def pg_conn():
+    """Provide a real PostgreSQL connection. Rolls back after each test."""
+    import psycopg2
+
+    conn = psycopg2.connect(
+        host=PG_HOST,
+        port=PG_PORT,
+        user=PG_USER,
+        password=PG_PASSWORD,
+        database=PG_DATABASE,
+    )
+    yield conn
+    conn.rollback()
+    conn.close()
+
+
+@pytest.fixture
+def pg_table(pg_conn):
+    """Create a uniquely-named test table and drop it after the test."""
+    table_name = f"test_bench_{os.getpid()}_{id(pg_conn)}"
+    yield table_name, pg_conn
+    with pg_conn.cursor() as cur:
+        cur.execute(f"DROP TABLE IF EXISTS {table_name}")
+    pg_conn.commit()
 
 # Make project root importable for all integration tests
 PROJECT_ROOT = Path(__file__).parent.parent.parent

--- a/tests/integration/test_postgres_push_metrics.py
+++ b/tests/integration/test_postgres_push_metrics.py
@@ -15,7 +15,6 @@ Setup:
 
 import json
 import os
-from pathlib import Path
 
 import pytest
 
@@ -77,15 +76,25 @@ class TestPushToPostgres:
         columns_before = get_existing_columns(conn, table)
         assert "p50_latency_ms" not in columns_before
         # Verify all expected columns from _sample_metrics
-        for col in ["id", "created_at", "timestamp", "commit", "command",
-                    "data_size", "pipeline", "clients", "rps",
-                    "avg_latency_ms", "p99_latency_ms"]:
-            assert col in columns_before, f"Expected column '{col}' missing after first push"
+        for col in [
+            "id",
+            "created_at",
+            "timestamp",
+            "commit",
+            "command",
+            "data_size",
+            "pipeline",
+            "clients",
+            "rps",
+            "avg_latency_ms",
+            "p99_latency_ms",
+        ]:
+            assert (
+                col in columns_before
+            ), f"Expected column '{col}' missing after first push"
 
         # Second push: adds p50_latency_ms
-        metrics_v2 = [
-            {**_sample_metrics(commit="def456"), "p50_latency_ms": 0.3}
-        ]
+        metrics_v2 = [{**_sample_metrics(commit="def456"), "p50_latency_ms": 0.3}]
         push_to_postgres(metrics_v2, conn, table)
 
         columns_after = get_existing_columns(conn, table)
@@ -177,7 +186,9 @@ class TestProcessCommitMetrics:
         commit_dir.mkdir()
         (commit_dir / "metrics.json").write_text(json.dumps([_sample_metrics()]))
 
-        count, skipped = process_commit_metrics(commit_dir, conn, table, test_type="fts")
+        count, skipped = process_commit_metrics(
+            commit_dir, conn, table, test_type="fts"
+        )
         assert count == 1
         assert skipped is False
 

--- a/tests/integration/test_postgres_push_metrics.py
+++ b/tests/integration/test_postgres_push_metrics.py
@@ -1,0 +1,197 @@
+"""Integration tests for push_to_postgres.py against a real PostgreSQL instance.
+
+Setup:
+    These tests expect a PostgreSQL instance running at localhost:5433.
+    Currently using Docker:
+
+        docker run -d --name test-postgres -p 5433:5432 \
+            -e POSTGRES_USER=testuser \
+            -e POSTGRES_PASSWORD=valkey-search \
+            -e POSTGRES_DB=testdb \
+            postgres:15-alpine
+
+    If Postgres is not available, all tests are skipped gracefully via pytest.skip().
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from .conftest import requires_postgres
+
+from utils.push_to_postgres import (
+    push_to_postgres,
+    process_commit_metrics,
+    get_existing_columns,
+    create_or_update_table,
+    analyze_metrics_schema,
+)
+
+
+@pytest.fixture
+def metrics_table(pg_conn):
+    """Create a unique metrics table name and drop it after the test."""
+    table_name = f"test_metrics_{os.getpid()}"
+    yield table_name, pg_conn
+    with pg_conn.cursor() as cur:
+        cur.execute(f"DROP TABLE IF EXISTS {table_name}")
+    pg_conn.commit()
+
+
+def _sample_metrics(commit="abc123", command="GET", rps=150000.0):
+    return {
+        "timestamp": "2024-06-01T12:00:00Z",
+        "commit": commit,
+        "command": command,
+        "data_size": 64,
+        "pipeline": 1,
+        "clients": 50,
+        "rps": rps,
+        "avg_latency_ms": 0.45,
+        "p99_latency_ms": 1.2,
+    }
+
+
+@requires_postgres
+class TestPushToPostgres:
+    def test_basic_push_and_query(self, metrics_table):
+        table, conn = metrics_table
+        metrics = [_sample_metrics(), _sample_metrics(command="SET", rps=120000.0)]
+
+        count = push_to_postgres(metrics, conn, table)
+        assert count == 2
+
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM {table}")
+            assert cur.fetchone()[0] == 2
+
+    def test_schema_evolution_adds_column(self, metrics_table):
+        table, conn = metrics_table
+
+        # First push: no p50 field
+        metrics_v1 = [_sample_metrics()]
+        push_to_postgres(metrics_v1, conn, table)
+
+        columns_before = get_existing_columns(conn, table)
+        assert "p50_latency_ms" not in columns_before
+        # Verify all expected columns from _sample_metrics
+        for col in ["id", "created_at", "timestamp", "commit", "command",
+                    "data_size", "pipeline", "clients", "rps",
+                    "avg_latency_ms", "p99_latency_ms"]:
+            assert col in columns_before, f"Expected column '{col}' missing after first push"
+
+        # Second push: adds p50_latency_ms
+        metrics_v2 = [
+            {**_sample_metrics(commit="def456"), "p50_latency_ms": 0.3}
+        ]
+        push_to_postgres(metrics_v2, conn, table)
+
+        columns_after = get_existing_columns(conn, table)
+        assert "p50_latency_ms" in columns_after
+
+        # Old row should have NULL for new column
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT p50_latency_ms FROM {table} WHERE commit = 'abc123'")
+            assert cur.fetchone()[0] is None
+
+    def test_dry_run_no_side_effects(self, metrics_table):
+        table, conn = metrics_table
+        metrics = [_sample_metrics()]
+
+        count = push_to_postgres(metrics, conn, table, dry_run=True)
+        assert count == 1
+
+        # Table should not exist
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT EXISTS (SELECT FROM information_schema.tables "
+                "WHERE table_name = %s)",
+                (table,),
+            )
+            assert cur.fetchone()[0] is False
+
+    def test_correct_column_types(self, metrics_table):
+        table, conn = metrics_table
+        metrics = [_sample_metrics()]
+        push_to_postgres(metrics, conn, table)
+
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT column_name, data_type FROM information_schema.columns "
+                "WHERE table_name = %s",
+                (table,),
+            )
+            col_types = {row[0]: row[1] for row in cur.fetchall()}
+
+        assert col_types["rps"] == "numeric"  # DECIMAL maps to numeric
+        assert col_types["pipeline"] == "integer"
+        assert "timestamp" in col_types["timestamp"].lower()
+
+
+@requires_postgres
+class TestCreateOrUpdateTable:
+    def test_creates_table_and_adds_missing_columns(self, metrics_table):
+        table, conn = metrics_table
+
+        # Create with initial schema
+        schema_v1 = analyze_metrics_schema([_sample_metrics()])
+        create_or_update_table(conn, schema_v1, table)
+
+        columns = get_existing_columns(conn, table)
+        assert "commit" in columns
+        assert "timestamp" in columns
+        assert "rps" in columns
+        assert "id" in columns
+        assert "created_at" in columns
+
+        # Check indexes were created
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT indexname FROM pg_indexes WHERE tablename = %s",
+                (table,),
+            )
+            indexes = [r[0] for r in cur.fetchall()]
+        assert f"idx_{table}_commit" in indexes
+        assert f"idx_{table}_timestamp" in indexes
+        assert f"idx_{table}_command" in indexes
+        assert f"idx_{table}_config" in indexes
+
+        # Update with extended schema — adds new column, keeps existing
+        assert "new_field" not in columns
+        schema_v2 = {**schema_v1, "new_field": "INTEGER"}
+        create_or_update_table(conn, schema_v2, table)
+
+        columns_after = get_existing_columns(conn, table)
+        assert "new_field" in columns_after
+        assert "rps" in columns_after
+        assert "commit" in columns_after
+
+
+@requires_postgres
+class TestProcessCommitMetrics:
+    def test_with_test_type(self, metrics_table, tmp_path):
+        table, conn = metrics_table
+        commit_dir = tmp_path / "abc123"
+        commit_dir.mkdir()
+        (commit_dir / "metrics.json").write_text(json.dumps([_sample_metrics()]))
+
+        count, skipped = process_commit_metrics(commit_dir, conn, table, test_type="fts")
+        assert count == 1
+        assert skipped is False
+
+        # Verify test_type was added
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT test_type FROM {table}")
+            assert cur.fetchone()[0] == "fts"
+
+    def test_skips_missing_file(self, metrics_table, tmp_path):
+        """process_commit_metrics skips gracefully when no metrics.json exists."""
+        table, conn = metrics_table
+        commit_dir = tmp_path / "nofile"
+        commit_dir.mkdir()
+
+        count, skipped = process_commit_metrics(commit_dir, conn, table)
+        assert count == 0
+        assert skipped is True

--- a/tests/integration/test_postgres_track_commits.py
+++ b/tests/integration/test_postgres_track_commits.py
@@ -1,0 +1,487 @@
+"""Integration tests for postgres_track_commits.py against a real PostgreSQL instance.
+
+Setup:
+    These tests expect a PostgreSQL instance running at localhost:5433.
+    Currently using Docker:
+
+        docker run -d --name test-postgres -p 5433:5432 \
+            -e POSTGRES_USER=testuser \
+            -e POSTGRES_PASSWORD=valkey-search \
+            -e POSTGRES_DB=testdb \
+            postgres:15-alpine
+
+    If Postgres is not available, all tests are skipped gracefully via pytest.skip().
+"""
+
+import os
+
+import pytest
+from psycopg2.extras import Json
+
+from .conftest import requires_postgres, GitRepoFixture
+
+from utils.postgres_track_commits import (
+    create_tables,
+    mark_commits,
+    cleanup_incomplete_commits,
+    determine_commits_to_benchmark,
+    get_commits_by_config,
+    get_unique_configs,
+    _resolve_module_table_name,
+    CORE_TABLE_NAME,
+)
+
+
+@pytest.fixture
+def track_table(pg_conn):
+    """Create a unique tracking table and drop it after the test."""
+    table_name = f"test_track_{os.getpid()}"
+    create_tables(pg_conn, table_name, table_id="core")
+    yield table_name, pg_conn
+    with pg_conn.cursor() as cur:
+        cur.execute(f"DROP TABLE IF EXISTS {table_name}")
+    pg_conn.commit()
+
+
+@pytest.fixture
+def repo_with_commits(tmp_path) -> GitRepoFixture:
+    """Git repo with 5 commits on main branch."""
+    repo = GitRepoFixture(tmp_path / "repo")
+    for i in range(4):  # initial commit + 4 more = 5 total
+        repo.create_commit(f"Commit {i+2}")
+    return repo
+
+
+@requires_postgres
+class TestCreateTables:
+    def test_core_table_columns_indexes_constraints(self, pg_conn):
+        try:
+            create_tables(pg_conn, table_id="core")
+
+            # Check columns
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = %s ORDER BY ordinal_position",
+                    (CORE_TABLE_NAME,),
+                )
+                columns = [r[0] for r in cur.fetchall()]
+            assert "id" in columns
+            assert "sha" in columns
+            assert "timestamp" in columns
+            assert "status" in columns
+            assert "config" in columns
+            assert "architecture" in columns
+            assert "created_at" in columns
+            assert "updated_at" in columns
+
+            # Check indexes (core uses prefix "_")
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT indexname FROM pg_indexes WHERE tablename = %s",
+                    (CORE_TABLE_NAME,),
+                )
+                indexes = [r[0] for r in cur.fetchall()]
+            assert "idx_commits_sha" in indexes
+            assert "idx_commits_status" in indexes
+            assert "idx_commits_timestamp" in indexes
+            assert "idx_commits_config" in indexes
+            assert "idx_commits_sha_status" in indexes
+
+            # Check unique constraint
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT constraint_name FROM information_schema.table_constraints "
+                    "WHERE table_name = %s AND constraint_type = 'UNIQUE'",
+                    (CORE_TABLE_NAME,),
+                )
+                constraints = [r[0] for r in cur.fetchall()]
+            assert "unique_sha_config_arch" in constraints
+
+        finally:
+            with pg_conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {CORE_TABLE_NAME}")
+            pg_conn.commit()
+
+    def test_module_table_columns_indexes_constraints(self, pg_conn):
+        table = _resolve_module_table_name("search")
+        try:
+            create_tables(pg_conn, table, table_id="search")
+
+            # Check columns (same schema as core)
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = %s ORDER BY ordinal_position",
+                    (table,),
+                )
+                columns = [r[0] for r in cur.fetchall()]
+            assert "sha" in columns
+            assert "config" in columns
+            assert "architecture" in columns
+
+            # Check indexes (module uses prefix "_search_")
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT indexname FROM pg_indexes WHERE tablename = %s",
+                    (table,),
+                )
+                indexes = [r[0] for r in cur.fetchall()]
+            assert "idx_search_commits_sha" in indexes
+            assert "idx_search_commits_status" in indexes
+            assert "idx_search_commits_timestamp" in indexes
+            assert "idx_search_commits_config" in indexes
+            assert "idx_search_commits_sha_status" in indexes
+
+            # Check unique constraint with module prefix
+            with pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT constraint_name FROM information_schema.table_constraints "
+                    "WHERE table_name = %s AND constraint_type = 'UNIQUE'",
+                    (table,),
+                )
+                constraints = [r[0] for r in cur.fetchall()]
+            assert "unique_search_sha_config_arch" in constraints
+
+        finally:
+            with pg_conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {table}")
+            pg_conn.commit()
+
+    def test_idempotent(self, pg_conn):
+        table = f"test_idem_{os.getpid()}"
+        try:
+            create_tables(pg_conn, table, table_id="core")
+            create_tables(pg_conn, table, table_id="core")  # no error
+        finally:
+            with pg_conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {table}")
+            pg_conn.commit()
+
+
+@requires_postgres
+class TestMarkAndQuery:
+    def test_mark_upsert_and_architecture_isolation(
+        self, track_table, repo_with_commits
+    ):
+        table, conn = track_table
+        repo = repo_with_commits
+        sha = repo.get_current_commit()
+        config = [{"data_sizes": [16, 64], "io-threads": 1}]
+
+        # Mark as in_progress, verify
+        mark_commits(conn, repo.path, [sha], "in_progress", "x86_64", config, table)
+        results = get_commits_by_config(conn, "x86_64", config, table)
+        assert len(results) == 1
+        assert results[0]["sha"] == sha
+        assert results[0]["status"] == "in_progress"
+
+        # Upsert to complete, verify only 1 row and status updated
+        mark_commits(conn, repo.path, [sha], "complete", "x86_64", config, table)
+        results = get_commits_by_config(conn, "x86_64", config, table)
+        assert len(results) == 1
+        assert results[0]["status"] == "complete"
+
+        # arm64 should see nothing
+        results = get_commits_by_config(conn, "arm64", config, table)
+        assert len(results) == 0
+
+    def test_head_resolves_to_current_sha(self, track_table, repo_with_commits):
+        table, conn = track_table
+        repo = repo_with_commits
+        current_sha = repo.get_current_commit()
+        config = [{"data_sizes": [16]}]
+
+        mark_commits(conn, repo.path, ["HEAD"], "complete", "x86_64", config, table)
+
+        results = get_commits_by_config(conn, "x86_64", config, table)
+        assert len(results) == 1
+        assert results[0]["sha"] == current_sha  # resolved, not "HEAD"
+
+    def test_mark_multiple_shas_in_one_call(self, track_table, repo_with_commits):
+        table, conn = track_table
+        repo = repo_with_commits
+        config = [{"data_sizes": [16]}]
+
+        # All 5 commit SHAs from the repo
+        shas = determine_commits_to_benchmark(
+            conn,
+            repo.path,
+            "HEAD",
+            max_commits=10,
+            architecture="x86_64",
+            config=config,
+            table_name=table,
+        )
+        assert len(shas) == 5
+
+        mark_commits(conn, repo.path, shas, "complete", "x86_64", config, table)
+
+        results = get_commits_by_config(conn, "x86_64", config, table)
+        assert len(results) == 5
+        assert {r["sha"] for r in results} == set(shas)
+
+    def test_get_commits_by_config_none_returns_all(
+        self, track_table, repo_with_commits
+    ):
+        table, conn = track_table
+        repo = repo_with_commits
+        sha = repo.get_current_commit()
+
+        config_a = [{"data_sizes": [16]}]
+        config_b = [{"data_sizes": [64]}]
+        mark_commits(conn, repo.path, [sha], "complete", "x86_64", config_a, table)
+        mark_commits(conn, repo.path, [sha], "complete", "x86_64", config_b, table)
+
+        # config=None -> no config filter, both rows returned
+        results = get_commits_by_config(conn, "x86_64", config=None, table_name=table)
+        assert len(results) == 2
+
+
+@requires_postgres
+class TestCleanup:
+    def test_removes_in_progress(self, track_table, repo_with_commits):
+        table, conn = track_table
+        repo = repo_with_commits
+        sha = repo.get_current_commit()
+        config = [{"data_sizes": [16]}]
+
+        mark_commits(conn, repo.path, [sha], "in_progress", "x86_64", config, table)
+        removed = cleanup_incomplete_commits(
+            conn, table, config=config, architecture="x86_64"
+        )
+        assert removed == 1
+
+        results = get_commits_by_config(conn, "x86_64", config, table)
+        assert len(results) == 0
+
+    def test_does_not_remove_complete(self, track_table, repo_with_commits):
+        table, conn = track_table
+        repo = repo_with_commits
+        sha = repo.get_current_commit()
+        config = [{"data_sizes": [16]}]
+
+        mark_commits(conn, repo.path, [sha], "complete", "x86_64", config, table)
+        removed = cleanup_incomplete_commits(
+            conn, table, config=config, architecture="x86_64"
+        )
+        assert removed == 0
+
+
+@requires_postgres
+class TestDetermineCommits:
+    def test_determine_returns_skips_and_respects_max(
+        self, track_table, repo_with_commits
+    ):
+        table, conn = track_table
+        repo = repo_with_commits
+        config = [{"data_sizes": [16]}]
+
+        # All 5 commits unbenchmarked
+        commits = determine_commits_to_benchmark(
+            conn,
+            repo.path,
+            "HEAD",
+            max_commits=10,
+            architecture="x86_64",
+            config=config,
+            table_name=table,
+        )
+        assert len(commits) == 5
+
+        # Mark one as complete, should return 4
+        sha = repo.get_current_commit()
+        mark_commits(conn, repo.path, [sha], "complete", "x86_64", config, table)
+        commits = determine_commits_to_benchmark(
+            conn,
+            repo.path,
+            "HEAD",
+            max_commits=10,
+            architecture="x86_64",
+            config=config,
+            table_name=table,
+        )
+        assert sha not in commits
+        assert len(commits) == 4
+
+        # Respects max_commits
+        commits = determine_commits_to_benchmark(
+            conn,
+            repo.path,
+            "HEAD",
+            max_commits=2,
+            architecture="x86_64",
+            config=config,
+            table_name=table,
+        )
+        assert len(commits) == 2
+
+
+@requires_postgres
+class TestSubsetDetection:
+    def test_list_config_subset_skipped(self, track_table, repo_with_commits):
+        table, conn = track_table
+        repo = repo_with_commits
+        sha = repo.get_current_commit()
+
+        superset_config = [{"data_sizes": [16, 64, 256], "io-threads": 1}]
+        mark_commits(
+            conn, repo.path, [sha], "complete", "x86_64", superset_config, table
+        )
+
+        subset_config = [{"data_sizes": [16, 64], "io-threads": 1}]
+        commits = determine_commits_to_benchmark(
+            conn,
+            repo.path,
+            "HEAD",
+            max_commits=10,
+            architecture="x86_64",
+            config=subset_config,
+            table_name=table,
+        )
+        assert sha not in commits
+
+    def test_dict_config_subset_skipped(self, track_table, repo_with_commits):
+        table, conn = track_table
+        repo = repo_with_commits
+        sha = repo.get_current_commit()
+
+        superset_config = {"data_sizes": [16, 64, 256], "io-threads": 1, "tls": True}
+        mark_commits(
+            conn, repo.path, [sha], "complete", "x86_64", superset_config, table
+        )
+
+        subset_config = {"data_sizes": [16, 64], "io-threads": 1}
+        commits = determine_commits_to_benchmark(
+            conn,
+            repo.path,
+            "HEAD",
+            max_commits=10,
+            architecture="x86_64",
+            config=subset_config,
+            table_name=table,
+        )
+        assert sha not in commits
+
+    def test_non_subset_not_skipped(self, track_table, repo_with_commits):
+        table, conn = track_table
+        repo = repo_with_commits
+        sha = repo.get_current_commit()
+
+        stored_config = [{"data_sizes": [16], "io-threads": 1}]
+        mark_commits(conn, repo.path, [sha], "complete", "x86_64", stored_config, table)
+
+        different_config = [{"data_sizes": [64, 128], "io-threads": 2}]
+        commits = determine_commits_to_benchmark(
+            conn,
+            repo.path,
+            "HEAD",
+            max_commits=10,
+            architecture="x86_64",
+            config=different_config,
+            table_name=table,
+        )
+        assert sha in commits
+
+    def test_disable_subset_detection_does_not_skip(
+        self, track_table, repo_with_commits
+    ):
+        table, conn = track_table
+        repo = repo_with_commits
+        sha = repo.get_current_commit()
+
+        superset_config = [{"data_sizes": [16, 64, 256], "io-threads": 1}]
+        mark_commits(
+            conn, repo.path, [sha], "complete", "x86_64", superset_config, table
+        )
+
+        subset_config = [{"data_sizes": [16, 64], "io-threads": 1}]
+        commits = determine_commits_to_benchmark(
+            conn,
+            repo.path,
+            "HEAD",
+            max_commits=10,
+            architecture="x86_64",
+            config=subset_config,
+            enable_subset_detection=False,
+            table_name=table,
+        )
+        # Detection is off, so the subset is still returned for benchmarking
+        assert sha in commits
+
+    def test_subset_detection_with_module_table(self, pg_conn, repo_with_commits):
+        core_table = CORE_TABLE_NAME
+        module_table = _resolve_module_table_name("search")
+        try:
+            create_tables(pg_conn, core_table, table_id="core")
+            create_tables(pg_conn, module_table, table_id="search")
+            repo = repo_with_commits
+            sha = repo.get_current_commit()
+
+            # Store superset in core table
+            superset_config = [{"data_sizes": [16, 64, 256]}]
+            mark_commits(
+                pg_conn,
+                repo.path,
+                [sha],
+                "complete",
+                "x86_64",
+                superset_config,
+                core_table,
+            )
+
+            # Query module table with subset — should NOT be skipped (different table)
+            subset_config = [{"data_sizes": [16]}]
+            commits = determine_commits_to_benchmark(
+                pg_conn,
+                repo.path,
+                "HEAD",
+                max_commits=10,
+                architecture="x86_64",
+                config=subset_config,
+                table_name=module_table,
+            )
+            assert sha in commits
+
+            # Now store superset in module table too — should be skipped
+            mark_commits(
+                pg_conn,
+                repo.path,
+                [sha],
+                "complete",
+                "x86_64",
+                superset_config,
+                module_table,
+            )
+            commits = determine_commits_to_benchmark(
+                pg_conn,
+                repo.path,
+                "HEAD",
+                max_commits=10,
+                architecture="x86_64",
+                config=subset_config,
+                table_name=module_table,
+            )
+            assert sha not in commits
+        finally:
+            with pg_conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS {core_table}")
+                cur.execute(f"DROP TABLE IF EXISTS {module_table}")
+            pg_conn.commit()
+
+
+@requires_postgres
+class TestGetUniqueConfigs:
+    def test_returns_distinct_configs(self, track_table, repo_with_commits):
+        table, conn = track_table
+        repo = repo_with_commits
+        sha = repo.get_current_commit()
+
+        config_a = [{"data_sizes": [16], "io-threads": 1}]
+        config_b = [{"data_sizes": [64], "io-threads": 2}]
+
+        mark_commits(conn, repo.path, [sha], "complete", "x86_64", config_a, table)
+        mark_commits(conn, repo.path, [sha], "complete", "x86_64", config_b, table)
+
+        configs = get_unique_configs(conn, table)
+        assert len(configs) == 2

--- a/tests/integration/test_postgres_track_commits.py
+++ b/tests/integration/test_postgres_track_commits.py
@@ -16,7 +16,6 @@ Setup:
 import os
 
 import pytest
-from psycopg2.extras import Json
 
 from .conftest import requires_postgres, GitRepoFixture
 


### PR DESCRIPTION
## Summary

Adds integration tests that exercise `utils/postgres_track_commits.py` and
`utils/push_to_postgres.py` against a real PostgreSQL instance, covering behavior
that the existing unit tests (which mock the DB) can't verify — real schema
creation, JSONB queries, upserts, and dynamic schema evolution.

## What's included

- **`tests/integration/test_postgres_track_commits.py`** (16 tests)
  - Table/index/constraint creation for core and module (`search`) tables
  - `create_tables` idempotency
  - `mark_commits` upsert + architecture isolation
  - `"HEAD"` resolves to the concrete commit SHA before storage
  - Marking multiple SHAs in a single call
  - `cleanup_incomplete_commits` (removes `in_progress`, preserves `complete`)
  - `determine_commits_to_benchmark` — skip logic + `max_commits`
  - Subset detection (list configs, dict configs, per-table isolation) and the
    `enable_subset_detection=False` path
  - `get_commits_by_config` with `config=None` (returns all for architecture)
  - `get_unique_configs`

- **`tests/integration/test_postgres_push_metrics.py`** (7 tests)
  - Basic push + row count
  - Dynamic schema evolution (new column added on later push, old rows NULL)
  - `dry_run` performs no writes
  - Correct Postgres column types
  - `create_or_update_table` creates schema + indexes, then adds missing columns
  - `process_commit_metrics` with `test_type`, and graceful skip on missing file

- **`tests/integration/conftest.py`**
  - Adds `pg_conn` / `pg_table` fixtures and a `requires_postgres` skip marker
  - Connection settings overridable via `TEST_PG_*` env vars (defaults:
    `localhost:5433`, user `testuser`, db `testdb`)

## Running locally

Tests skip gracefully when no PostgreSQL is reachable. To run them:

    docker run -d --name test-postgres -p 5433:5432 \
        -e POSTGRES_USER=testuser \
        -e POSTGRES_PASSWORD=valkey-search \
        -e POSTGRES_DB=testdb \
        postgres:15-alpine

    python -m pytest tests/integration/ -v

