### PR TITLE
Add multi-run restart support for modules

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -11,7 +11,7 @@ import sys
 
 
 from valkey_build import ServerBuilder
-from valkey_server import ServerLauncher
+from valkey_server import ServerLauncher, apply_config_to_servers
 from valkey_benchmark import ClientRunner
 from benchmark_build import BenchmarkBuilder
 from utils.cpu_utils import (
@@ -650,7 +650,13 @@ def _execute_benchmark_run(
 
     # Apply config set
     if exec_config["config_set"] and not args.skip_config_set:
-        _apply_config_to_servers(exec_config["config_set"], cfg, args.target_ip)
+        apply_config_to_servers(
+            exec_config["config_set"],
+            _get_active_ports(cfg),
+            args.target_ip,
+            tls_mode=cfg.get("tls_mode", False),
+            valkey_dir=valkey_dir,
+        )
 
     # Run benchmark client
     if args.mode in ("client", "both"):
@@ -701,20 +707,6 @@ def _execute_benchmark_run(
     # Shutdown server
     if launcher and not args.use_running_server:
         launcher.shutdown(cfg["tls_mode"])
-
-
-def _apply_config_to_servers(config_set: dict, cfg: dict, target_ip: str) -> None:
-    """Apply CONFIG SET commands to all server nodes."""
-    import valkey
-
-    for port in _get_active_ports(cfg):
-        client = valkey.Valkey(host=target_ip, port=port)
-        try:
-            for k, v in config_set.items():
-                client.execute_command("CONFIG", "SET", k, str(v))
-                logging.info(f"Set {k} = {v} on port {port}")
-        finally:
-            client.close()
 
 
 def get_module_binary_path(args: argparse.Namespace, config: dict) -> Optional[str]:

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -15,7 +15,7 @@ from typing import Iterable, List, Optional
 import valkey
 
 from process_metrics import MetricsProcessor
-from valkey_server import ServerLauncher
+from valkey_server import ServerLauncher, apply_config_to_servers
 from profiler import PerformanceProfiler
 from utils.git_utils import resolve_ref, get_commit_timestamp
 
@@ -280,6 +280,16 @@ class ClientRunner:
         except Exception as e:
             logging.error(f"Failed to flush database: {e}")
             raise RuntimeError(f"Database flush failed: {e}")
+
+    def _apply_config_set(self, config_set: dict) -> None:
+        """Apply CONFIG SET commands to all server nodes after restart."""
+        apply_config_to_servers(
+            config_set,
+            self._get_active_ports(),
+            self.target_ip,
+            tls_mode=self.tls_mode,
+            valkey_dir=self.valkey_path,
+        )
 
     def _populate_keyspace(
         self,
@@ -868,7 +878,13 @@ class ClientRunner:
         logging.info(f"Running scenario: {scenario_id} (type: {scenario_type})")
 
         if scenario.get("flush_before", False):
-            self._flush_database()
+            if self.server_launcher:
+                self._restart_server()
+                # Re-apply config_set after restart since CONFIG SET values are lost
+                if config_set:
+                    self._apply_config_set(config_set)
+            else:
+                self._flush_database()
 
         for setup_cmd in scenario.get("setup_commands", []):
             self._execute_setup_command(setup_cmd)
@@ -1484,12 +1500,13 @@ class ClientRunner:
         # Shutdown current server
         self.server_launcher.shutdown(self.tls_mode)
 
-        # Start fresh server (module_path is stored in launcher)
+        # Start fresh server (module_path and config are stored in launcher)
         self.server_launcher.launch(
             cluster_mode=self.cluster_mode,
             tls_mode=self.tls_mode,
             io_threads=self.io_threads,
             module_path=self.server_launcher.module_path,
+            config=self.server_launcher.config,
         )
 
         # Wait for server to be ready

--- a/valkey_server.py
+++ b/valkey_server.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Iterable, List, Optional
 
 import valkey
 
@@ -13,6 +13,46 @@ import valkey
 VALKEY_SERVER = "src/valkey-server"
 DEFAULT_PORT = 6379
 DEFAULT_TIMEOUT = 15
+
+
+def apply_config_to_servers(
+    config_set: dict,
+    ports: List[int],
+    target_ip: str,
+    tls_mode: bool = False,
+    valkey_dir: Optional[Path] = None,
+) -> None:
+    """Apply CONFIG SET commands to all server nodes.
+
+    Args:
+        config_set: Dict of config key-value pairs to set.
+        ports: List of server ports to apply config to.
+        target_ip: Host IP of the server(s).
+        tls_mode: Whether to connect with TLS.
+        valkey_dir: Path to valkey directory (needed for TLS cert paths).
+    """
+    kwargs_base = {"decode_responses": True, "socket_timeout": 10}
+    if tls_mode:
+        if valkey_dir is None:
+            raise ValueError("valkey_dir is required when tls_mode is True")
+        tls_cert_path = Path(valkey_dir) / "tests" / "tls"
+        kwargs_base.update(
+            {
+                "ssl": True,
+                "ssl_certfile": str(tls_cert_path / "valkey.crt"),
+                "ssl_keyfile": str(tls_cert_path / "valkey.key"),
+                "ssl_ca_certs": str(tls_cert_path / "ca.crt"),
+            }
+        )
+
+    for port in ports:
+        client = valkey.Valkey(host=target_ip, port=port, **kwargs_base)
+        try:
+            for k, v in config_set.items():
+                client.execute_command("CONFIG", "SET", k, str(v))
+                logging.info(f"Set {k} = {v} on port {port}")
+        finally:
+            client.close()
 
 
 class ServerLauncher:

--- a/valkey_server.py
+++ b/valkey_server.py
@@ -36,6 +36,8 @@ def apply_config_to_servers(
         if valkey_dir is None:
             raise ValueError("valkey_dir is required when tls_mode is True")
         tls_cert_path = Path(valkey_dir) / "tests" / "tls"
+        if not tls_cert_path.exists():
+            raise FileNotFoundError(f"TLS certificates not found at {tls_cert_path}")
         kwargs_base.update(
             {
                 "ssl": True,
@@ -490,6 +492,8 @@ class ServerLauncher:
         """Launch Valkey server and setup cluster if needed."""
         self.config = config
         self.module_path = module_path
+        # Reset node tracking so a restart doesn't accumulate stale entries
+        self.cluster_nodes = []
 
         # Setup modules: CLI overrides config path
         if module_path:


### PR DESCRIPTION
## Summary

When a benchmark scenario is marked `flush_before: true`, the tool previously issued a `FLUSHALL` to clear data between runs. `FLUSHALL` empties the keyspace but leaves the *same server process* running, so memory fragmentation, allocator state, and module-held structures (e.g. search index memory) carry over and skew back-to-back measurements.

This PR changes `flush_before` to perform a full **server restart** when the tool owns the server (a `ServerLauncher` is present), giving each run a genuinely fresh process. When no launcher is present (benchmarking a server we didn't start), it falls back to the existing `FLUSHALL` behavior.

## Changes

- **Restart on `flush_before`** (`valkey_benchmark.py`): in `_run_single_scenario`, if a `ServerLauncher` exists, restart the server instead of flushing; otherwise flush as before.
- **Re-apply `config_set` after restart** (`valkey_benchmark.py`): a restart drops runtime `CONFIG SET` values, so they are replayed onto the fresh server. `_restart_server` now also passes the launcher's startup `config` through to `launch()` so startup args are preserved across the restart.
- **Shared config-application helper** (`benchmark.py`, `valkey_server.py`): extracted the private `_apply_config_to_servers` from `benchmark.py` into a module-level `apply_config_to_servers` in `valkey_server.py`, now used by both `benchmark.py` and `valkey_benchmark.py`. Added TLS support (cert paths under `<valkey_dir>/tests/tls`) and a socket timeout.
- **Cluster node-tracking fix** (`valkey_server.py`): `launch()` now resets `self.cluster_nodes` at the start of each call, so restarting (a second `launch()` on the same object) no longer accumulates stale node entries.

## Notes on `config_set`

`config_set` (runtime `CONFIG SET` tuning) only exists in the `test_groups` config format; the `simple` format never carries it. The re-apply logic added here lives on the `test_groups` path accordingly. (The pre-existing `simple` path already restarts when a launcher is present, but has no `config_set` to re-apply.)

## Tradeoffs

- Each `flush_before` scenario now pays a full shutdown + relaunch + readiness wait instead of a `FLUSHALL`. Across many scenarios and multiple runs this increases total wall-clock time. This is intentional: clean process state matters for accurate module/search memory measurements.
