### PR TITLE
Fix profiling run to one

### DIFF
--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -351,9 +351,7 @@ class ClientRunner:
         When profiling is enabled we only run once.
         """
         if self.current_profiling_set.get("enabled", False) and self.runs > 1:
-            logging.info(
-                "Profiling enabled: forcing runs=1 (profiling runs only once)"
-            )
+            logging.info("Profiling enabled: forcing runs=1 (profiling runs only once)")
             return 1
         return self.runs
 

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -345,6 +345,18 @@ class ClientRunner:
         # Finalize and write results
         self._finalize_metrics(metrics_processor, metric_json, profiling_enabled)
 
+    def _get_effective_runs(self) -> int:
+        """Return the number of runs to execute.
+
+        When profiling is enabled we only run once.
+        """
+        if self.current_profiling_set.get("enabled", False) and self.runs > 1:
+            logging.info(
+                "Profiling enabled: forcing runs=1 (profiling runs only once)"
+            )
+            return 1
+        return self.runs
+
     def _iterate_scenarios(self):
         """Generate scenario execution data from either config format."""
         if self.uses_test_groups:
@@ -375,8 +387,8 @@ class ClientRunner:
                 )
                 continue
 
-            # Run multiple times if requested
-            for run_num in range(self.runs):
+            # Run multiple times if requested (profiling forces a single run)
+            for run_num in range(self._get_effective_runs()):
                 seed_val = random.randint(0, 1000000)
 
                 yield {
@@ -399,7 +411,9 @@ class ClientRunner:
         """Generate scenarios from test_groups configuration.
 
         When ``self.runs > 1``, the entire group is repeated multiple times.
+        Profiling mode forces a single run (see ``_get_effective_runs``).
         """
+        effective_runs = self._get_effective_runs()
         groups_to_run = self.config.get("groups_to_run")
         scenario_filter = self.config.get("scenario_filter")
 
@@ -414,11 +428,11 @@ class ClientRunner:
                 )
                 continue
 
-            for run_num in range(self.runs):
-                if self.runs > 1:
+            for run_num in range(effective_runs):
+                if effective_runs > 1:
                     logging.info(
                         f"=== Group {group_id}: {group_description or ''} "
-                        f"(run {run_num + 1}/{self.runs}) ==="
+                        f"(run {run_num + 1}/{effective_runs}) ==="
                     )
                 else:
                     logging.info(f"=== Group {group_id}: {group_description or ''} ===")


### PR DESCRIPTION
This PR fix profiling to run once regardless of the num_run passed in. 

If later we want to enable multi-run on profiling, https://github.com/valkey-io/valkey-perf-benchmark/pull/76 must be implemented to enable correct file parsing. 