### PR TITLE
fix: increase all socket/readiness timeouts to 30s

### DIFF
--- a/valkey_server.py
+++ b/valkey_server.py
@@ -12,7 +12,7 @@ import valkey
 # Constants
 VALKEY_SERVER = "src/valkey-server"
 DEFAULT_PORT = 6379
-DEFAULT_TIMEOUT = 15
+DEFAULT_TIMEOUT = 30
 
 
 def apply_config_to_servers(
@@ -31,7 +31,7 @@ def apply_config_to_servers(
         tls_mode: Whether to connect with TLS.
         valkey_dir: Path to valkey directory (needed for TLS cert paths).
     """
-    kwargs_base = {"decode_responses": True, "socket_timeout": 10}
+    kwargs_base = {"decode_responses": True, "socket_timeout": 30}
     if tls_mode:
         if valkey_dir is None:
             raise ValueError("valkey_dir is required when tls_mode is True")
@@ -82,8 +82,8 @@ class ServerLauncher:
             "host": host,
             "port": port,
             "decode_responses": True,
-            "socket_timeout": 5,
-            "socket_connect_timeout": 5,
+            "socket_timeout": 30,
+            "socket_connect_timeout": 30,
         }
         if tls_mode:
             tls_cert_path = Path(self.valkey_path) / "tests" / "tls"


### PR DESCRIPTION
Root cause: socket_timeout=5s was too short for SHUTDOWN NOSAVE when server has 8 reader threads draining 1000 concurrent connections. The false timeout caused unnecessary escalation to SIGKILL, leaving the port in TIME_WAIT. The new server then failed with 'Address already in use' within the old 15s readiness window.

Changes:
- DEFAULT_TIMEOUT (server readiness): 15s → 30s
- _create_client socket_timeout: 5s → 30s
- _create_client socket_connect_timeout: 5s → 30s
- apply_config_to_servers socket_timeout: 10s → 30s