### PR TITLE
Unify basic and test_groups configs into a single execution path

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ Create benchmark configurations in JSON format. Each object represents a single 
 ]
 ```
 
+Internally, this basic format is compiled into the scenario model at load time: each combination of the list-valued fields (requests x keyspacelen x data_sizes x pipelines x clients x commands) becomes a generated test group containing a single scenario, and the runner executes only the `test_groups` path. This is purely an internal translation: benchmark invocations and `metrics.json` outputs are unchanged, and both the basic format and the `test_groups` format (see Module Config Structure) remain fully supported.
+
 #### Custom Server Configs Examples
 
 Add server configs the benchmark does not manage (e.g. memory limits, timeouts):
@@ -661,6 +663,18 @@ Module tests use structured `test_groups` with `scenarios`:
   "tls_mode": false
 }
 ```
+
+**Scenario fields:** Each scenario names its workload with exactly one of `test` or `command` (except `type: mixed` scenarios, which use `writes`/`reads` sub-scenarios instead):
+
+| Field            | Description                                                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `test`           | Predefined valkey-benchmark test name, run as `-t NAME`. Used by compiled basic-format configs.                                    |
+| `command`        | Arbitrary command line, run after `--`. Supports `__rand_int__` placeholders.                                                      |
+| `data_size`      | Payload size in bytes, passed as `-d N` when present.                                                                              |
+| `keyspacelen`    | Per-scenario key space size, passed as `-r N`. Falls back to the config-level `keyspacelen[0]`.                                    |
+| `warmup_inline`  | Adds `--warmup N` to the main benchmark run. Distinct from `warmup`, which performs a separate warm-up run first.                  |
+| `restart_before` | Restarts the managed server before the scenario runs (flushes the database instead when using a running server).                   |
+| `populate_with`  | Write workload that seeds the keyspace before a read test. For a `test` scenario it is a predefined write name (e.g. `SET`), run as `-t NAME`; for a `command` scenario it is an arbitrary write command string (e.g. `SET key:__rand_int__ __data__`), run after `--`. The populate pass runs sequentially and shares the main run's seed, so the read hits the seeded keys. |
 
 ### Cluster Mode Support
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import logging
 import platform
+from itertools import product
 from pathlib import Path
 from typing import List, Optional
 import sys
@@ -12,7 +13,14 @@ import sys
 
 from valkey_build import ServerBuilder
 from valkey_server import ServerLauncher, apply_config_to_servers
-from valkey_benchmark import ClientRunner
+from valkey_benchmark import (
+    ClientRunner,
+    ORIGIN_FIELD,
+    ORIGIN_SIMPLE,
+    READ_COMMANDS,
+    READ_POPULATE_MAP,
+    WRITE_COMMANDS,
+)
 from benchmark_build import BenchmarkBuilder
 from utils.cpu_utils import (
     parse_core_range,
@@ -286,6 +294,54 @@ def _validate_cpu_range(value, key_name: str) -> None:
 # ---------- Helpers ----------------------------------------------------------
 
 
+def compile_simple_config(cfg: dict) -> None:
+    """Compile the basic 'commands' format into generated test_groups.
+
+    Each parameter combination becomes a single-scenario group, preserving
+    consecutive run ordering. The origin marker preserves the basic metrics
+    schema and shared seed. Cluster-specific filtering happens later, after
+    cluster mode has been scalarized.
+    """
+    requests_list = (
+        cfg["requests"] if cfg.get("requests") is not None else [None]
+    )  # duration mode has no requests
+
+    groups = []
+    for requests, keyspacelen, data_size, pipeline, clients, command in product(
+        requests_list,
+        cfg["keyspacelen"],
+        cfg["data_sizes"],
+        cfg["pipelines"],
+        cfg["clients"],
+        cfg["commands"],
+    ):
+        if command not in READ_COMMANDS + WRITE_COMMANDS:
+            logging.warning(f"Unsupported command: {command}, skipping.")
+            continue
+
+        scenario = {
+            ORIGIN_FIELD: ORIGIN_SIMPLE,
+            "id": command,
+            "test": command,
+            "data_size": data_size,
+            "pipeline": pipeline,
+            "clients": clients,
+            "keyspacelen": keyspacelen,
+            "warmup_inline": cfg["warmup"],
+            "restart_before": True,
+        }
+        if cfg.get("duration") is not None:
+            scenario["duration"] = cfg["duration"]
+        else:
+            scenario["requests"] = requests
+        if command in READ_COMMANDS:
+            scenario["populate_with"] = READ_POPULATE_MAP[command]
+
+        groups.append({"group": len(groups) + 1, "scenarios": [scenario]})
+
+    cfg["test_groups"] = groups
+
+
 def validate_config(cfg: dict) -> None:
     """Validate config (commands or test_groups format)."""
     if "scenarios" in cfg and "test_groups" not in cfg:
@@ -369,6 +425,9 @@ def validate_config(cfg: dict) -> None:
         cfg["cluster_mode"] = parse_bool(cfg["cluster_mode"])
     if "tls_mode" in cfg:
         cfg["tls_mode"] = parse_bool(cfg["tls_mode"])
+
+    if has_commands and not has_test_groups:
+        compile_simple_config(cfg)
 
 
 def load_configs(path: str) -> List[dict]:
@@ -477,6 +536,48 @@ def validate_test_groups(cfg: dict) -> None:
         if not isinstance(group["scenarios"], list) or len(group["scenarios"]) == 0:
             raise ValueError(f"test_groups[{i}].scenarios must be a non-empty list")
 
+        for j, scenario in enumerate(group["scenarios"]):
+            if not isinstance(scenario, dict):
+                raise ValueError(f"test_groups[{i}].scenarios[{j}] must be a dict")
+
+            if scenario.get("type") == "mixed":
+                if "populate_with" in scenario:
+                    raise ValueError(
+                        f"test_groups[{i}].scenarios[{j}] combines 'mixed' "
+                        "with 'populate_with'; mixed scenarios seed the "
+                        "keyspace through their own 'writes' sub-scenarios"
+                    )
+                continue
+
+            if ("test" in scenario) == ("command" in scenario):
+                raise ValueError(
+                    f"test_groups[{i}].scenarios[{j}] must have exactly one "
+                    "of 'test' or 'command'"
+                )
+
+            if "test" in scenario and "options" in scenario:
+                raise ValueError(
+                    f"test_groups[{i}].scenarios[{j}] combines 'test' with "
+                    "'options'; options append flags to the command string "
+                    "and are only valid with 'command', not 'test'"
+                )
+
+            if "populate_with" in scenario:
+                populate_with = scenario["populate_with"]
+                if not isinstance(populate_with, str) or not populate_with:
+                    raise ValueError(
+                        f"test_groups[{i}].scenarios[{j}] 'populate_with' must "
+                        "be a non-empty string"
+                    )
+                # Predefined tests require a supported write workload; command
+                # scenarios may use arbitrary populate commands.
+                if "test" in scenario and populate_with not in WRITE_COMMANDS:
+                    raise ValueError(
+                        f"test_groups[{i}].scenarios[{j}] 'populate_with' "
+                        f"{populate_with!r} is not a supported write command; "
+                        f"for a 'test' scenario it must be one of {WRITE_COMMANDS}"
+                    )
+
 
 def run_benchmark_matrix(
     *,
@@ -484,7 +585,6 @@ def run_benchmark_matrix(
     cfg: dict,
     args: argparse.Namespace,
     module_path: Optional[str] = None,
-    uses_test_groups: bool = False,
     config_name: Optional[str] = None,
     module_commit: Optional[str] = None,
     module_commit_timestamp: Optional[str] = None,
@@ -536,7 +636,6 @@ def run_benchmark_matrix(
             valkey_dir,
             commit_id,
             module_path,
-            uses_test_groups,
             architecture,
             client_cpu_ranges,
             config_name,
@@ -610,7 +709,6 @@ def _execute_benchmark_run(
     valkey_dir,
     commit_id,
     module_path,
-    uses_test_groups,
     architecture,
     client_cpu_ranges,
     config_name=None,
@@ -687,7 +785,6 @@ def _execute_benchmark_run(
             runs=args.runs,
             server_launcher=launcher,
             architecture=architecture,
-            uses_test_groups=uses_test_groups,
             repository=args.repository,
             config_name=config_name,
             module_commit=module_commit,
@@ -773,8 +870,6 @@ def main() -> None:
     config = configs_list[0]
     validate_cpu_allocation(config)
 
-    uses_test_groups = "test_groups" in config
-
     module_path = get_module_binary_path(args, config)
 
     # Module testing requires valkey-path
@@ -782,9 +877,8 @@ def main() -> None:
         print("ERROR: Module testing requires --valkey-path")
         sys.exit(1)
 
-    if uses_test_groups and (
-        config.get("dataset_generation") or config.get("query_generation")
-    ):
+    # Every validated config has test_groups (basic configs are compiled)
+    if config.get("dataset_generation") or config.get("query_generation"):
         import subprocess
 
         required_datasets = set()
@@ -825,7 +919,6 @@ def main() -> None:
     # Process all configs
     for cfg in configs_list:
         validate_cpu_allocation(cfg)
-        uses_test_groups = "test_groups" in cfg
 
         # Apply CLI filters to this config
         if args.groups:
@@ -840,7 +933,6 @@ def main() -> None:
                 cfg=cfg,
                 args=args,
                 module_path=module_path,
-                uses_test_groups=uses_test_groups,
                 config_name=Path(args.config).name if args.module else None,
                 module_commit=args.module_commit,
                 module_commit_timestamp=args.module_commit_timestamp,

--- a/process_metrics.py
+++ b/process_metrics.py
@@ -8,24 +8,7 @@ import logging
 
 
 class MetricsProcessor:
-    """Process metric output from ``valkey-benchmark``.
-
-    Parameters
-    ----------
-    commit_id : str
-        Git commit identifier of the tested build.
-    cluster_mode : bool
-        Whether cluster mode was enabled for the benchmark.
-    tls_mode : bool
-        Whether TLS was enabled for the benchmark.
-    commit_time : str
-        ISO8601 commit timestamp.
-    repository : str, optional
-        GitHub repository in "owner/repo" format (e.g., "valkey-io/valkey").
-    environment_metadata : dict, optional
-        System environment metadata (CPU governor, turbo state, kernel, etc.).
-        Flattened into top-level ``env_``-prefixed keys in each metric entry.
-    """
+    """Build and persist metric rows from ``valkey-benchmark`` output."""
 
     def __init__(
         self,
@@ -49,6 +32,62 @@ class MetricsProcessor:
         self.repository = repository
         self.environment_metadata = environment_metadata
 
+    def build_base_metadata(
+        self,
+        command: str,
+        data_size: int,
+        pipeline: int,
+        clients: int,
+        requests: Optional[int] = None,
+        warmup: Optional[int] = None,
+        duration: Optional[int] = None,
+    ) -> Dict[str, object]:
+        """Build metadata shared by successful and failed metric rows.
+
+        Performance fields must remain absent; their absence identifies failed
+        rows. Optional identity fields are emitted only when configured.
+        """
+        metadata: Dict[str, object] = {
+            "timestamp": self.commit_time,
+            "commit": self.commit_id,
+            "repository": self.repository,
+            "command": command,
+            "data_size": int(data_size),
+            "pipeline": int(pipeline),
+            "clients": int(clients),
+            "cluster_mode": self.cluster_mode,
+            "tls": self.tls_mode,
+        }
+
+        if duration is not None:
+            metadata["duration"] = int(duration)
+            metadata["benchmark_mode"] = "duration"
+        elif requests is not None:
+            metadata["requests"] = int(requests)
+            metadata["benchmark_mode"] = "requests"
+        else:
+            logging.warning("Neither requests nor duration specified")
+            metadata["benchmark_mode"] = "unknown"
+
+        if self.io_threads is not None:
+            metadata["io_threads"] = self.io_threads
+
+        if self.benchmark_threads is not None:
+            metadata["valkey_benchmark_threads"] = self.benchmark_threads
+
+        if warmup is not None:
+            metadata["warmup"] = warmup
+
+        if self.architecture is not None:
+            metadata["architecture"] = self.architecture
+
+        # Downstream tables require flat columns.
+        if self.environment_metadata:
+            for key, value in self.environment_metadata.items():
+                metadata[f"env_{key}"] = value
+
+        return metadata
+
     def create_metrics(
         self,
         benchmark_data: Dict[str, Any],
@@ -60,31 +99,13 @@ class MetricsProcessor:
         warmup: Optional[int] = None,
         duration: Optional[int] = None,
     ) -> Optional[Dict[str, object]]:
-        """Create a complete metrics dictionary from CSV output and benchmark parameters.
-
-        Parameters
-        ----------
-        benchmark_data : Dict[str, Any]
-            CSV output from ``valkey-benchmark``.
-        command : str
-            Benchmark command that was executed.
-        data_size : int
-            Size of the payload in bytes.
-        pipeline : int
-            Number of commands pipelined.
-        clients : int
-            Concurrent client connections used.
-        requests : int
-            Total number of requests issued.
-        warmup : int, optional
-            Warmup time in seconds.
-        """
+        """Add parsed performance measurements to the row metadata."""
         if not benchmark_data:
             logging.warning("Empty benchmark output received")
             return None
 
         try:
-            # Helper function to safely convert to float
+
             def safe_float(value, default=0.0):
                 try:
                     return float(value) if value else default
@@ -94,64 +115,32 @@ class MetricsProcessor:
                     )
                     return default
 
-            metrics_dict = {
-                "timestamp": self.commit_time,
-                "commit": self.commit_id,
-                "repository": self.repository,
-                "command": command,
-                "data_size": int(data_size),
-                "pipeline": int(pipeline),
-                "clients": int(clients),
-                "rps": safe_float(benchmark_data.get("rps")),
-                "avg_latency_ms": safe_float(benchmark_data.get("avg_latency_ms")),
-                "min_latency_ms": safe_float(benchmark_data.get("min_latency_ms")),
-                "p50_latency_ms": safe_float(benchmark_data.get("p50_latency_ms")),
-                "p95_latency_ms": safe_float(benchmark_data.get("p95_latency_ms")),
-                "p99_latency_ms": safe_float(benchmark_data.get("p99_latency_ms")),
-                "max_latency_ms": safe_float(benchmark_data.get("max_latency_ms")),
-                "cluster_mode": self.cluster_mode,
-                "tls": self.tls_mode,
-            }
+            metrics_dict = self.build_base_metadata(
+                command,
+                data_size,
+                pipeline,
+                clients,
+                requests=requests,
+                warmup=warmup,
+                duration=duration,
+            )
 
-            # Add requests or duration based on benchmark mode
-            if duration is not None:
-                metrics_dict["duration"] = int(duration)
-                metrics_dict["benchmark_mode"] = "duration"
-            elif requests is not None:
-                metrics_dict["requests"] = int(requests)
-                metrics_dict["benchmark_mode"] = "requests"
-            else:
-                logging.warning("Neither requests nor duration specified")
-                metrics_dict["benchmark_mode"] = "unknown"
-
-            # Add io_threads to metrics if it was specified
-            if self.io_threads is not None:
-                metrics_dict["io_threads"] = self.io_threads
-
-            # Add benchmark_threads to metrics if it was specified
-            if self.benchmark_threads is not None:
-                metrics_dict["valkey_benchmark_threads"] = self.benchmark_threads
-
-            # Add warmup to metrics if it was specified
-            if warmup is not None:
-                metrics_dict["warmup"] = warmup
-
-            # Add architecture to metrics if it was specified
-            if self.architecture is not None:
-                metrics_dict["architecture"] = self.architecture
-
-            # Add environment metadata for reproducibility. Flattened into
-            # top-level "env_"-prefixed keys because metrics entries are
-            # converted to columns downstream (nested dicts don't map to
-            # columns).
-            if self.environment_metadata:
-                for key, value in self.environment_metadata.items():
-                    metrics_dict[f"env_{key}"] = value
+            metrics_dict.update(
+                {
+                    "rps": safe_float(benchmark_data.get("rps")),
+                    "avg_latency_ms": safe_float(benchmark_data.get("avg_latency_ms")),
+                    "min_latency_ms": safe_float(benchmark_data.get("min_latency_ms")),
+                    "p50_latency_ms": safe_float(benchmark_data.get("p50_latency_ms")),
+                    "p95_latency_ms": safe_float(benchmark_data.get("p95_latency_ms")),
+                    "p99_latency_ms": safe_float(benchmark_data.get("p99_latency_ms")),
+                    "max_latency_ms": safe_float(benchmark_data.get("max_latency_ms")),
+                }
+            )
 
             return metrics_dict
         except Exception:
-            logging.exception(f"Error parsing CSV output")
-            logging.debug(f"Raw output: {benchmark_csv_data}")
+            logging.exception("Error parsing CSV output")
+            logging.debug(f"Raw output: {benchmark_data}")
             return None
 
     def write_metrics(
@@ -165,17 +154,15 @@ class MetricsProcessor:
         metrics_file = results_dir / "metrics.json"
         metrics = []
 
-        # Ensure results directory exists
         results_dir.mkdir(parents=True, exist_ok=True)
 
-        # Load existing metrics if file exists
         if metrics_file.exists() and metrics_file.stat().st_size > 0:
             try:
                 with metrics_file.open("r", encoding="utf-8") as f:
                     metrics = json.load(f)
                 if not isinstance(metrics, list):
                     logging.warning(
-                        f"Existing metrics file contains non-list data, starting fresh"
+                        "Existing metrics file contains non-list data, starting fresh"
                     )
                     metrics = []
             except json.JSONDecodeError as e:
@@ -187,10 +174,8 @@ class MetricsProcessor:
                 logging.error(f"Error reading existing metrics file: {e}")
                 raise
 
-        # Extend metrics with new_metrics
         metrics.extend(new_metrics)
 
-        # Write metrics with atomic operation
         temp_file = metrics_file.with_suffix(".tmp")
         try:
             with temp_file.open("w", encoding="utf-8") as f:

--- a/tests/integration/test_benchmark_execution.py
+++ b/tests/integration/test_benchmark_execution.py
@@ -5,15 +5,16 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
-from .conftest import GitRepoFixture, MockBenchmarkBinary, PROJECT_ROOT
+from .conftest import PROJECT_ROOT
 
 from benchmark import load_configs
 from valkey_benchmark import ClientRunner
 from process_metrics import MetricsProcessor
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -43,14 +44,13 @@ def _make_runner(config, *, tls_mode=False, cores=None) -> ClientRunner:
     )
 
 
-_DEFAULT_BUILD_KWARGS = dict(
+_DEFAULT_BUILD_SCENARIO = dict(
+    test="GET",
     requests=100,
     keyspacelen=1000,
     data_size=16,
     pipeline=1,
     clients=10,
-    command="GET",
-    seed_val=12345,
 )
 
 
@@ -146,9 +146,11 @@ class TestMockBenchmarkExecution:
 class TestBenchmarkCommandBuilding:
     """Test benchmark command construction."""
 
-    def test_build_simple_command(self, minimal_benchmark_config):
+    def test_build_test_workload_command(self, minimal_benchmark_config):
         runner = _make_runner(minimal_benchmark_config)
-        cmd = runner._build_benchmark_command(tls=False, **_DEFAULT_BUILD_KWARGS)
+        cmd = runner._build_benchmark_command(
+            dict(_DEFAULT_BUILD_SCENARIO), tls=False, seed_val=12345
+        )
 
         assert "/tmp/valkey-benchmark" in cmd
         for token in ("-n", "100", "-t", "GET", "--csv"):
@@ -156,14 +158,18 @@ class TestBenchmarkCommandBuilding:
 
     def test_build_tls_command(self, minimal_benchmark_config):
         runner = _make_runner(minimal_benchmark_config, tls_mode=True)
-        cmd = runner._build_benchmark_command(tls=True, **_DEFAULT_BUILD_KWARGS)
+        cmd = runner._build_benchmark_command(
+            dict(_DEFAULT_BUILD_SCENARIO), tls=True, seed_val=12345
+        )
 
         for token in ("--tls", "--cert", "--key", "--cacert"):
             assert token in cmd
 
     def test_build_command_with_cpu_pinning(self, minimal_benchmark_config):
         runner = _make_runner(minimal_benchmark_config, cores="0-3")
-        cmd = runner._build_benchmark_command(tls=False, **_DEFAULT_BUILD_KWARGS)
+        cmd = runner._build_benchmark_command(
+            dict(_DEFAULT_BUILD_SCENARIO), tls=False, seed_val=12345
+        )
 
         assert "taskset" in cmd
         assert "-c" in cmd
@@ -295,7 +301,7 @@ class TestEndToEndWithMock:
         except subprocess.TimeoutExpired as e:
             # Timeout means it got past config loading — expected
             output = (e.stdout or b"").decode() + (e.stderr or b"").decode()
-            assert len(output) > 0, f"Expected benchmark to start, got no output"
+            assert len(output) > 0, "Expected benchmark to start, got no output"
 
     def test_benchmark_generates_metrics_with_mock_server(
         self, mock_valkey_repo, tmp_path
@@ -351,3 +357,113 @@ class TestEndToEndWithMock:
             cwd=PROJECT_ROOT,
         )
         assert result.returncode != 0
+
+
+class TestCompiledBasicFormatRun:
+    _CSV_HEADER = (
+        '"test","rps","avg_latency_ms","min_latency_ms","p50_latency_ms",'
+        '"p95_latency_ms","p99_latency_ms","max_latency_ms"'
+    )
+    _CSV_ROW = '"100000.00","0.500","0.100","0.400","0.800","1.200","2.000"'
+
+    _EXPECTED_BASIC_KEYS = {
+        "timestamp",
+        "commit",
+        "repository",
+        "command",
+        "data_size",
+        "pipeline",
+        "clients",
+        "rps",
+        "avg_latency_ms",
+        "min_latency_ms",
+        "p50_latency_ms",
+        "p95_latency_ms",
+        "p99_latency_ms",
+        "max_latency_ms",
+        "cluster_mode",
+        "tls",
+        "requests",
+        "benchmark_mode",
+        "warmup",
+        "architecture",
+    }
+    _TEST_GROUPS_ONLY_KEYS = {
+        "test_id",
+        "test_phase",
+        "group",
+        "scenario",
+        "config_set",
+        "status",
+        "group_description",
+        "scenario_description",
+        "config_name",
+        "dataset",
+        "module_commit",
+        "module_commit_timestamp",
+    }
+
+    def _canned_csv(self, cmd):
+        name = cmd[cmd.index("-t") + 1] if "-t" in cmd else "SCENARIO"
+        return f'{self._CSV_HEADER}\n"{name}",{self._CSV_ROW}\n'
+
+    def test_run_ordering_and_metrics_schema(self, tmp_path):
+        config_path = _write_config(
+            tmp_path,
+            [
+                {
+                    "requests": [100],
+                    "keyspacelen": [1000],
+                    "data_sizes": [16],
+                    "pipelines": [1],
+                    "clients": [1],
+                    "commands": ["SET", "GET"],
+                    "cluster_mode": False,
+                    "tls_mode": False,
+                    "warmup": 0,
+                }
+            ],
+        )
+        cfg = load_configs(str(config_path))[0]
+
+        runner = ClientRunner(
+            commit_id="abc123",
+            config=cfg,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=tmp_path,
+            valkey_path="/tmp/valkey",
+            valkey_benchmark_path="src/valkey-benchmark",
+            architecture="test-arch",
+        )
+
+        invocations = []
+
+        def fake_run(command=None, *args, **kwargs):
+            invocations.append(list(command))
+            if kwargs.get("capture_output"):
+                return SimpleNamespace(stdout=self._canned_csv(list(command)))
+            return None
+
+        with (
+            patch.object(runner, "_run", side_effect=fake_run),
+            patch.object(runner, "_flush_database"),
+            patch.object(ClientRunner, "get_commit_time", lambda self, cid: "<TS>"),
+            patch(
+                "valkey_benchmark.collect_environment_metadata",
+                lambda **kwargs: {"numa_nodes": "1"},
+            ),
+            patch("valkey_benchmark.random.randint", return_value=555),
+        ):
+            runner.run_benchmark_config()
+
+        order = [(c[c.index("-t") + 1], "--sequential" in c) for c in invocations]
+        assert order == [("SET", False), ("SET", True), ("GET", False)]
+
+        metrics = json.loads((tmp_path / "metrics.json").read_text())
+        assert [m["command"] for m in metrics] == ["SET", "GET"]
+        for row in metrics:
+            non_env = {k for k in row if not k.startswith("env_")}
+            assert non_env == self._EXPECTED_BASIC_KEYS
+            assert not (set(row) & self._TEST_GROUPS_ONLY_KEYS)

--- a/tests/test_benchmark_command.py
+++ b/tests/test_benchmark_command.py
@@ -1,105 +1,215 @@
 """Unit tests for ClientRunner._build_benchmark_command."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
+
+from benchmark import validate_config
+
+
+def _compiled_basic_scenario(command):
+    """Return the scenario produced by compiling a one-command basic config."""
+    cfg = {
+        "requests": [100],
+        "keyspacelen": [1000],
+        "data_sizes": [16],
+        "pipelines": [1],
+        "clients": [1],
+        "commands": [command],
+        "cluster_mode": False,
+        "tls_mode": False,
+        "warmup": 0,
+    }
+    validate_config(cfg)
+    return cfg["test_groups"][0]["scenarios"][0]
+
+
+_COMPILED_ARGV_PREFIX = [
+    "src/valkey-benchmark",
+    "-h",
+    "127.0.0.1",
+    "-p",
+    "6379",
+    "-n",
+    "100",
+    "-r",
+    "1000",
+    "-d",
+    "16",
+    "-P",
+    "1",
+    "-c",
+    "1",
+]
 
 
 @pytest.fixture
-def base_cmd_params():
-    """Common parameters shared across _build_benchmark_command tests."""
-    return dict(
-        requests=100, keyspacelen=100, data_size=32, pipeline=1, clients=10, seed_val=1
+def base_test_scenario():
+    """Common predefined-workload (-t) scenario shared across builder tests."""
+    return {
+        "test": "GET",
+        "requests": 100,
+        "keyspacelen": 100,
+        "data_size": 32,
+        "pipeline": 1,
+        "clients": 10,
+    }
+
+
+class TestBuildBenchmarkCommandTestFormat:
+    """Test predefined-workload scenarios ('test' field) produce correct flags."""
+
+    @pytest.mark.parametrize(
+        "cluster_mode, drop_nodes, expect_cluster",
+        [
+            (True, False, True),
+            (True, True, True),  # must not depend on cluster_nodes metadata
+            (False, False, False),
+        ],
     )
-
-
-class TestBuildBenchmarkCommandSimpleFormat:
-    """Test simple format (no scenario) produces correct flags."""
-
-    def test_simple_format_contains_all_flags(self, minimal_client_runner):
-        """Simple format command includes all expected positional flags."""
-        cmd = minimal_client_runner._build_benchmark_command(
-            tls=False,
-            requests=1000,
-            keyspacelen=5000,
-            data_size=64,
-            pipeline=1,
-            clients=50,
-            command="GET",
-            seed_val=42,
-        )
-
-        assert cmd[0] == "src/valkey-benchmark"
-        assert "-h" in cmd
-        assert cmd[cmd.index("-h") + 1] == "127.0.0.1"
-        assert "-p" in cmd
-        assert cmd[cmd.index("-p") + 1] == "6379"
-        assert "-n" in cmd
-        assert cmd[cmd.index("-n") + 1] == "1000"
-        assert "-r" in cmd
-        assert cmd[cmd.index("-r") + 1] == "5000"
-        assert "-d" in cmd
-        assert cmd[cmd.index("-d") + 1] == "64"
-        assert "-P" in cmd
-        assert cmd[cmd.index("-P") + 1] == "1"
-        assert "-c" in cmd
-        assert cmd[cmd.index("-c") + 1] == "50"
-        assert "-t" in cmd
-        assert cmd[cmd.index("-t") + 1] == "GET"
-        assert "--seed" in cmd
-        assert cmd[cmd.index("--seed") + 1] == "42"
-        assert "--csv" in cmd
-
-    def test_simple_format_no_taskset_by_default(
-        self, minimal_client_runner, base_cmd_params
+    def test_test_format_cluster_flag(
+        self,
+        minimal_client_runner,
+        base_test_scenario,
+        cluster_mode,
+        drop_nodes,
+        expect_cluster,
     ):
-        """Without CPU pinning, taskset should not appear."""
-        cmd = minimal_client_runner._build_benchmark_command(
-            command="SET", **base_cmd_params
-        )
-        assert "taskset" not in cmd
+        """--cluster tracks cluster_mode and never depends on cluster_nodes."""
+        minimal_client_runner.cluster_mode = cluster_mode
+        if drop_nodes:
+            minimal_client_runner.config.pop("cluster_nodes", None)
 
-    def test_simple_format_includes_cluster_flag_in_cluster_mode(
-        self, minimal_client_runner, base_cmd_params
+        cmd = minimal_client_runner._build_benchmark_command(
+            base_test_scenario, seed_val=1
+        )
+
+        assert ("--cluster" in cmd) is expect_cluster
+
+    @pytest.mark.parametrize("warmup_inline, expect_flag", [(10, True), (0, False)])
+    def test_test_format_warmup_inline(
+        self, minimal_client_runner, base_test_scenario, warmup_inline, expect_flag
     ):
-        """Simple format commands include --cluster when cluster mode is enabled."""
-        minimal_client_runner.cluster_mode = True
+        """warmup_inline > 0 emits --warmup N on the main invocation; 0 omits it."""
+        base_test_scenario["warmup_inline"] = warmup_inline
 
         cmd = minimal_client_runner._build_benchmark_command(
-            command="SET", **base_cmd_params
+            base_test_scenario, seed_val=1
         )
 
-        assert "--cluster" in cmd
+        assert ("--warmup" in cmd) is expect_flag
+        if expect_flag:
+            assert cmd[cmd.index("--warmup") + 1] == str(warmup_inline)
 
-    def test_simple_format_omits_cluster_flag_when_cluster_mode_disabled(
-        self, minimal_client_runner, base_cmd_params
+    def test_test_format_benchmark_threads(
+        self, minimal_client_runner, base_test_scenario
     ):
-        """Simple format commands should not include --cluster outside cluster mode."""
+        """benchmark-threads emits --threads for test-format scenarios."""
+        minimal_client_runner.benchmark_threads = 4
+
         cmd = minimal_client_runner._build_benchmark_command(
-            command="SET", **base_cmd_params
+            base_test_scenario, seed_val=1
         )
 
-        assert "--cluster" not in cmd
+        assert "--threads" in cmd
+        assert cmd[cmd.index("--threads") + 1] == "4"
 
-    def test_simple_format_includes_cluster_flag_without_cluster_nodes_config(
-        self, minimal_client_runner, base_cmd_params
+    def test_test_format_requires_requests_or_duration(
+        self, minimal_client_runner, base_test_scenario
     ):
-        """Issue #27 regression: cluster mode should not depend on cluster_nodes metadata."""
-        minimal_client_runner.cluster_mode = True
-        minimal_client_runner.config.pop("cluster_nodes", None)
+        """A test-format scenario without requests or duration is rejected."""
+        del base_test_scenario["requests"]
+
+        with pytest.raises(ValueError):
+            minimal_client_runner._build_benchmark_command(
+                base_test_scenario, seed_val=1
+            )
+
+    def test_test_format_keyspacelen_falls_back_to_config(
+        self, minimal_client_runner, base_test_scenario
+    ):
+        """Without per-scenario keyspacelen, config-level keyspacelen[0] is used."""
+        del base_test_scenario["keyspacelen"]
 
         cmd = minimal_client_runner._build_benchmark_command(
-            command="SET", **base_cmd_params
+            base_test_scenario, seed_val=1
         )
 
-        assert "--cluster" in cmd
+        # minimal_valid_config has keyspacelen [1000]
+        assert cmd[cmd.index("-r") + 1] == "1000"
+
+    def test_write_workload_exact_argv(self, minimal_client_runner):
+        scenario = _compiled_basic_scenario("SET")
+        with patch("valkey_benchmark.random.randint", return_value=42):
+            cmd = minimal_client_runner._build_benchmark_command(scenario, tls=False)
+
+        assert cmd == [
+            *_COMPILED_ARGV_PREFIX,
+            "-t",
+            "SET",
+            "--seed",
+            "42",
+            "--csv",
+        ]
+
+    def test_read_workload_populate_and_main_exact_argv(self, minimal_client_runner):
+        scenario = _compiled_basic_scenario("GET")
+        captured = []
+
+        def fake_run(command=None, *args, **kwargs):
+            captured.append(list(command))
+            return MagicMock()
+
+        with (
+            patch.object(minimal_client_runner, "_run", side_effect=fake_run),
+            patch.object(minimal_client_runner, "_flush_database"),
+            patch("valkey_benchmark.random.randint", return_value=777),
+        ):
+            minimal_client_runner._run_single_scenario(
+                scenario,
+                group_id=1,
+                profiler=None,
+                metrics_processor=None,
+                config_set={},
+                config_suffix="default",
+            )
+
+        assert len(captured) == 2
+        populate_cmd, main_cmd = captured
+
+        assert populate_cmd == [
+            *_COMPILED_ARGV_PREFIX,
+            "-t",
+            "SET",
+            "--sequential",
+            "--seed",
+            "777",
+            "--csv",
+        ]
+        assert main_cmd == [
+            *_COMPILED_ARGV_PREFIX,
+            "-t",
+            "GET",
+            "--seed",
+            "777",
+            "--csv",
+        ]
+        assert (
+            populate_cmd[populate_cmd.index("--seed") + 1]
+            == main_cmd[main_cmd.index("--seed") + 1]
+            == "777"
+        )
+        assert "--sequential" in populate_cmd
+        assert "--sequential" not in main_cmd
 
 
 class TestBuildBenchmarkCommandTLS:
     """Test TLS mode includes TLS flags."""
 
-    def test_tls_flags_present(self, minimal_client_runner, base_cmd_params):
+    def test_tls_flags_present(self, minimal_client_runner, base_test_scenario):
         """When tls=True, TLS cert/key/cacert flags are included."""
         cmd = minimal_client_runner._build_benchmark_command(
-            tls=True, command="GET", **base_cmd_params
+            base_test_scenario, tls=True, seed_val=1
         )
 
         assert "--tls" in cmd
@@ -110,10 +220,12 @@ class TestBuildBenchmarkCommandTLS:
         assert "--cacert" in cmd
         assert cmd[cmd.index("--cacert") + 1] == "./tests/tls/ca.crt"
 
-    def test_no_tls_flags_when_disabled(self, minimal_client_runner, base_cmd_params):
+    def test_no_tls_flags_when_disabled(
+        self, minimal_client_runner, base_test_scenario
+    ):
         """When tls=False, no TLS flags appear."""
         cmd = minimal_client_runner._build_benchmark_command(
-            tls=False, command="GET", **base_cmd_params
+            base_test_scenario, tls=False, seed_val=1
         )
         assert "--tls" not in cmd
         assert "--cert" not in cmd
@@ -123,11 +235,11 @@ class TestBuildBenchmarkCommandCPUPinning:
     """Test CPU pinning prepends taskset."""
 
     def test_cpu_range_param_prepends_taskset(
-        self, minimal_client_runner, base_cmd_params
+        self, minimal_client_runner, base_test_scenario
     ):
         """Passing cpu_range prepends taskset -c <range> to the command."""
         cmd = minimal_client_runner._build_benchmark_command(
-            command="GET", cpu_range="0-3", **base_cmd_params
+            base_test_scenario, cpu_range="0-3", seed_val=1
         )
 
         assert cmd[0] == "taskset"
@@ -135,11 +247,13 @@ class TestBuildBenchmarkCommandCPUPinning:
         assert cmd[2] == "0-3"
         assert cmd[3] == "src/valkey-benchmark"
 
-    def test_self_cores_prepends_taskset(self, minimal_client_runner, base_cmd_params):
+    def test_self_cores_prepends_taskset(
+        self, minimal_client_runner, base_test_scenario
+    ):
         """When self.cores is set, taskset is prepended."""
         minimal_client_runner.cores = "4-7"
         cmd = minimal_client_runner._build_benchmark_command(
-            command="SET", **base_cmd_params
+            base_test_scenario, seed_val=1
         )
 
         assert cmd[0] == "taskset"
@@ -151,12 +265,14 @@ class TestBuildBenchmarkCommandDuration:
     """Test duration mode uses --duration instead of -n."""
 
     def test_duration_flag_replaces_requests(
-        self, minimal_client_runner, base_cmd_params
+        self, minimal_client_runner, base_test_scenario
     ):
         """When duration is provided, --duration is used instead of -n."""
-        base_cmd_params["requests"] = None
+        base_test_scenario.pop("requests")
+        base_test_scenario["duration"] = 30
+
         cmd = minimal_client_runner._build_benchmark_command(
-            command="GET", duration=30, **base_cmd_params
+            base_test_scenario, seed_val=1
         )
 
         assert "--duration" in cmd
@@ -166,12 +282,14 @@ class TestBuildBenchmarkCommandDuration:
     def test_no_duration_uses_requests(self, minimal_client_runner):
         """Without duration, -n flag is used with requests count."""
         cmd = minimal_client_runner._build_benchmark_command(
-            requests=5000,
-            keyspacelen=100,
-            data_size=32,
-            pipeline=1,
-            clients=10,
-            command="GET",
+            {
+                "test": "GET",
+                "requests": 5000,
+                "keyspacelen": 100,
+                "data_size": 32,
+                "pipeline": 1,
+                "clients": 10,
+            },
             seed_val=1,
         )
 
@@ -183,63 +301,97 @@ class TestBuildBenchmarkCommandDuration:
 class TestBuildBenchmarkCommandScenarios:
     """Test scenario-based command construction."""
 
-    def test_single_node_scenario_includes_cluster_flag_in_cluster_mode(
+    def test_arbitrary_command_omits_data_size_when_unset(self, minimal_client_runner):
+        """Scenarios that do not ask for a payload size keep their existing argv."""
+        cmd = minimal_client_runner._build_benchmark_command(
+            scenario={"command": "SET foo bar", "type": "write"}
+        )
+
+        assert "-d" not in cmd
+
+    def test_arbitrary_command_omits_threads_when_unconfigured(
         self, minimal_client_runner
     ):
-        """Scenario commands include --cluster for single-node execution in cluster mode."""
-        minimal_client_runner.cluster_mode = True
+        """No benchmark-threads in config means valkey-benchmark's own default."""
+        minimal_client_runner.benchmark_threads = None
 
         cmd = minimal_client_runner._build_benchmark_command(
-            scenario={
-                "command": "SET foo bar",
-                "type": "write",
-                "cluster_execution": "single",
-            }
+            scenario={"command": "SET foo bar", "type": "write"}
         )
 
-        assert "--cluster" in cmd
+        assert "--threads" not in cmd
 
-    def test_single_node_scenario_includes_cluster_flag_without_cluster_nodes_config(
-        self, minimal_client_runner
+    @pytest.mark.parametrize(
+        "cluster_mode, execution, drop_nodes, expect_cluster",
+        [
+            (True, "single", False, True),
+            (True, "single", True, True),  # routing must not depend on cluster_nodes
+            (True, "parallel", False, False),
+            (False, "single", False, False),
+        ],
+    )
+    def test_scenario_cluster_flag(
+        self,
+        minimal_client_runner,
+        cluster_mode,
+        execution,
+        drop_nodes,
+        expect_cluster,
     ):
-        """Scenario cluster routing should not depend on cluster_nodes metadata."""
-        minimal_client_runner.cluster_mode = True
-        minimal_client_runner.config.pop("cluster_nodes", None)
+        """--cluster is added only for single-node execution inside cluster mode,
+        never for parallel execution, and never depends on cluster_nodes."""
+        minimal_client_runner.cluster_mode = cluster_mode
+        if drop_nodes:
+            minimal_client_runner.config.pop("cluster_nodes", None)
 
         cmd = minimal_client_runner._build_benchmark_command(
             scenario={
                 "command": "SET foo bar",
                 "type": "write",
-                "cluster_execution": "single",
+                "cluster_execution": execution,
             }
         )
 
-        assert "--cluster" in cmd
+        assert ("--cluster" in cmd) is expect_cluster
 
-    def test_parallel_scenario_omits_cluster_flag(self, minimal_client_runner):
-        """Parallel cluster execution should not pass --cluster to a single command."""
-        minimal_client_runner.cluster_mode = True
+    def test_arbitrary_command_exact_argv(self, minimal_client_runner):
+        minimal_client_runner.benchmark_threads = 4
+        scenario = {
+            "command": "SET key:__rand_int__ __data__",
+            "type": "write",
+            "data_size": 128,
+            "requests": 100,
+            "pipeline": 1,
+            "clients": 1,
+            "keyspacelen": 1000,
+        }
 
-        cmd = minimal_client_runner._build_benchmark_command(
-            scenario={
-                "command": "SET foo bar",
-                "type": "write",
-                "cluster_execution": "parallel",
-            }
-        )
+        with patch("valkey_benchmark.random.randint", return_value=99):
+            cmd = minimal_client_runner._build_benchmark_command(scenario, tls=False)
 
-        assert "--cluster" not in cmd
-
-    def test_single_node_scenario_omits_cluster_flag_when_cluster_mode_disabled(
-        self, minimal_client_runner
-    ):
-        """Scenario commands should not include --cluster outside cluster mode."""
-        cmd = minimal_client_runner._build_benchmark_command(
-            scenario={
-                "command": "SET foo bar",
-                "type": "write",
-                "cluster_execution": "single",
-            }
-        )
-
-        assert "--cluster" not in cmd
+        assert cmd == [
+            "src/valkey-benchmark",
+            "-h",
+            "127.0.0.1",
+            "-p",
+            "6379",
+            "-n",
+            "100",
+            "-c",
+            "1",
+            "-P",
+            "1",
+            "-r",
+            "1000",
+            "-d",
+            "128",
+            "--threads",
+            "4",
+            "--seed",
+            "99",
+            "--csv",
+            "--",
+            "SET",
+            "key:__rand_int__",
+            "__data__",
+        ]

--- a/tests/test_benchmark_config.py
+++ b/tests/test_benchmark_config.py
@@ -347,39 +347,112 @@ class TestValidatePositiveIntOrList:
 # ---------------------------------------------------------------------------
 
 
+def _tg(scenario):
+    """Wrap a single scenario dict in the minimal test_groups config shape."""
+    return {"test_groups": [{"scenarios": [scenario]}]}
+
+
 class TestValidateTestGroups:
     """Tests for validate_test_groups."""
 
     def test_no_test_groups_key_passes(self):
         validate_test_groups({})  # should not raise
 
-    def test_not_a_list_raises(self):
-        with pytest.raises(ValueError, match="must be a non-empty list"):
-            validate_test_groups({"test_groups": "not a list"})
+    @pytest.mark.parametrize(
+        "cfg, match",
+        [
+            ({"test_groups": "not a list"}, "must be a non-empty list"),
+            ({"test_groups": []}, "must be a non-empty list"),
+            ({"test_groups": ["not a dict"]}, "must be a dict"),
+            ({"test_groups": [{"group": 1}]}, "missing 'scenarios' field"),
+            (
+                {"test_groups": [{"scenarios": []}]},
+                "scenarios must be a non-empty list",
+            ),
+            (
+                {"test_groups": [{"scenarios": "bad"}]},
+                "scenarios must be a non-empty list",
+            ),
+        ],
+    )
+    def test_invalid_container_structure_raises(self, cfg, match):
+        with pytest.raises(ValueError, match=match):
+            validate_test_groups(cfg)
 
-    def test_empty_list_raises(self):
-        with pytest.raises(ValueError, match="must be a non-empty list"):
-            validate_test_groups({"test_groups": []})
+    @pytest.mark.parametrize(
+        "scenario, match",
+        [
+            # exactly-one-of test/command
+            (
+                {"id": "s1", "test": "GET", "command": "GET key"},
+                "exactly one of 'test' or 'command'",
+            ),
+            ({"id": "s1", "clients": 1}, "exactly one of 'test' or 'command'"),
+            # options only valid with command
+            (
+                {"id": "s1", "test": "GET", "options": {"--foo": "_foo"}},
+                "only valid with 'command', not 'test'",
+            ),
+            # populate_with value validation (guards mutation: drop this check)
+            (
+                {"id": "s1", "test": "GET", "populate_with": 123},
+                "must be a non-empty string",
+            ),
+            (
+                {"id": "s1", "test": "GET", "populate_with": ""},
+                "must be a non-empty string",
+            ),
+            (
+                {"id": "s1", "test": "GET", "populate_with": "GET"},
+                "not a supported write command",
+            ),
+            # mixed scenarios seed through their own writes, never populate_with
+            (
+                {
+                    "id": "s1",
+                    "type": "mixed",
+                    "writes": [{"id": "w", "command": "SET foo bar"}],
+                    "reads": [{"id": "r", "command": "GET foo"}],
+                    "populate_with": "SET",
+                },
+                "combines 'mixed' with 'populate_with'",
+            ),
+        ],
+    )
+    def test_invalid_scenario_raises(self, scenario, match):
+        with pytest.raises(ValueError, match=match):
+            validate_test_groups(_tg(scenario))
 
-    def test_element_not_dict_raises(self):
-        with pytest.raises(ValueError, match="must be a dict"):
-            validate_test_groups({"test_groups": ["not a dict"]})
-
-    def test_element_missing_scenarios_raises(self):
-        with pytest.raises(ValueError, match="missing 'scenarios' field"):
-            validate_test_groups({"test_groups": [{"group": 1}]})
-
-    def test_empty_scenarios_raises(self):
-        with pytest.raises(ValueError, match="scenarios must be a non-empty list"):
-            validate_test_groups({"test_groups": [{"scenarios": []}]})
-
-    def test_scenarios_not_list_raises(self):
-        with pytest.raises(ValueError, match="scenarios must be a non-empty list"):
-            validate_test_groups({"test_groups": [{"scenarios": "bad"}]})
-
-    def test_valid_test_groups_passes(self):
-        cfg = {"test_groups": [{"scenarios": [{"id": "s1", "command": "GET key"}]}]}
-        validate_test_groups(cfg)  # should not raise
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            # plain command scenario
+            {"id": "s1", "command": "GET key"},
+            # test scenario seeded by a supported predefined write
+            {"id": "s1", "test": "GET", "populate_with": "SET"},
+            # options are valid on a command scenario
+            {
+                "id": "s1",
+                "command": "FT.SEARCH idx q",
+                "options": {"--nocontent": "_nocontent"},
+            },
+            # command scenario treats populate_with as an arbitrary write string
+            {
+                "id": "s1",
+                "command": "GET key:__rand_int__",
+                "populate_with": "SET key:__rand_int__ __data__",
+            },
+            # mixed scenario with no test/command and no populate_with
+            {
+                "id": "m1",
+                "type": "mixed",
+                "writes": [{"id": "w1", "command": "HSET k f v"}],
+                "reads": [{"id": "r1", "command": "FT.SEARCH idx q"}],
+            },
+        ],
+    )
+    def test_valid_scenario_passes(self, scenario):
+        validate_test_groups(_tg(scenario))  # should not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_client_runner_logic.py
+++ b/tests/test_client_runner_logic.py
@@ -1,19 +1,17 @@
 """Unit tests for pure logic methods on ClientRunner from valkey_benchmark.py."""
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from valkey_benchmark import ClientRunner
+from valkey_benchmark import ClientRunner, ORIGIN_FIELD, ORIGIN_SIMPLE
+from process_metrics import MetricsProcessor
 
 
 def _make_csv(rows):
-    """Build CSV stdout string from a list of metric dicts.
-
-    Each dict should contain keys like rps, avg_latency_ms, etc.
-    Returns a string with a header line and one data line per dict.
-    """
+    """Build CSV stdout from metric dictionaries."""
     header = '"test","rps","avg_latency_ms","min_latency_ms","p50_latency_ms","p95_latency_ms","p99_latency_ms","max_latency_ms"'
     lines = [header]
     for r in rows:
@@ -23,6 +21,64 @@ def _make_csv(rows):
             f'"{r["p99_latency_ms"]}","{r["max_latency_ms"]}"'
         )
     return "\n".join(lines)
+
+
+def _metric_row(test="GET", rps="1000.0"):
+    return {
+        "test": test,
+        "rps": rps,
+        "avg_latency_ms": "1.0",
+        "min_latency_ms": "0.5",
+        "p50_latency_ms": "1.0",
+        "p95_latency_ms": "2.0",
+        "p99_latency_ms": "3.0",
+        "max_latency_ms": "5.0",
+    }
+
+
+def _invoke_scenario(
+    runner,
+    scenario,
+    *,
+    metrics_processor,
+    profiler=None,
+    group_id=1,
+    config_set=None,
+    config_suffix="default",
+):
+    """Run a scenario with common test defaults."""
+    return runner._run_single_scenario(
+        scenario,
+        group_id=group_id,
+        profiler=profiler,
+        metrics_processor=metrics_processor,
+        config_set={} if config_set is None else config_set,
+        config_suffix=config_suffix,
+    )
+
+
+def _run_mixed(
+    runner,
+    scenario,
+    *,
+    metrics_processor,
+    group_id=1,
+    config_set=None,
+    warmup_duration=0,
+):
+    """Run a mixed scenario with common test defaults."""
+    return runner._run_mixed_workload(
+        scenario,
+        group_id=group_id,
+        config_set={} if config_set is None else config_set,
+        metrics_processor=metrics_processor,
+        warmup_duration=warmup_duration,
+    )
+
+
+def _seed_of(command):
+    assert "--seed" in command, f"no --seed in command: {command}"
+    return command[command.index("--seed") + 1]
 
 
 # ---------------------------------------------------------------------------
@@ -231,65 +287,86 @@ class TestShouldUseParallel:
 
 
 # ---------------------------------------------------------------------------
-# _generate_combinations
+# compile_simple_config (benchmark.py) replaces _generate_combinations:
+# the basic 'commands' format now compiles into generated test_groups.
 # ---------------------------------------------------------------------------
 
 
-class TestGenerateCombinations:
-    """Tests for ClientRunner._generate_combinations."""
+class TestCompileSimpleConfig:
+    """Tests for benchmark.compile_simple_config."""
 
-    def test_default_config(self, minimal_client_runner):
-        combos = minimal_client_runner._generate_combinations()
-        # requests=[1000], keyspacelen=[1000], data_sizes=[64], pipelines=[1],
-        # clients=[50], commands=["GET","SET"], warmup=0, duration=None
-        assert len(combos) == 2  # 1*1*1*1*1*2*1*1
+    def test_default_config(self, minimal_valid_config):
+        from benchmark import compile_simple_config
+
+        compile_simple_config(minimal_valid_config)
+        groups = minimal_valid_config["test_groups"]
+        assert len(groups) == 2
+        assert all(len(g["scenarios"]) == 1 for g in groups)
 
     def test_cartesian_product_count(self, minimal_valid_config):
+        from benchmark import compile_simple_config
+
         minimal_valid_config["data_sizes"] = [64, 128]
         minimal_valid_config["pipelines"] = [1, 10]
-        runner = ClientRunner(
-            commit_id="abc",
-            config=minimal_valid_config,
-            cluster_mode=False,
-            tls_mode=False,
-            target_ip="127.0.0.1",
-            results_dir=Path("/tmp"),
-            valkey_path="/tmp/valkey",
-            valkey_benchmark_path="src/valkey-benchmark",
-        )
-        combos = runner._generate_combinations()
-        # 1 * 1 * 2 * 2 * 1 * 2 * 1 * 1 = 8
-        assert len(combos) == 8
+        compile_simple_config(minimal_valid_config)
+        assert len(minimal_valid_config["test_groups"]) == 8
 
-    def test_tuple_structure(self, minimal_client_runner):
-        combos = minimal_client_runner._generate_combinations()
-        first = combos[0]
-        # (requests, keyspacelen, data_size, pipeline, clients, command, warmup, duration)
-        assert len(first) == 8
-        assert first[0] == 1000  # requests
-        assert first[1] == 1000  # keyspacelen
-        assert first[2] == 64  # data_size
-        assert first[3] == 1  # pipeline
-        assert first[4] == 50  # clients
-        assert first[5] in ("GET", "SET")
-        assert first[6] == 0  # warmup
-        assert first[7] is None  # duration
+    def test_generated_scenario_structure(self, minimal_valid_config):
+        from benchmark import compile_simple_config
+        from valkey_benchmark import ORIGIN_FIELD, ORIGIN_SIMPLE
 
-    def test_no_requests_key(self, minimal_valid_config):
+        compile_simple_config(minimal_valid_config)
+        first = minimal_valid_config["test_groups"][0]["scenarios"][0]
+
+        assert first[ORIGIN_FIELD] == ORIGIN_SIMPLE
+        assert first["test"] == "GET"
+        assert first["requests"] == 1000
+        assert first["keyspacelen"] == 1000
+        assert first["data_size"] == 64
+        assert first["pipeline"] == 1
+        assert first["clients"] == 50
+        assert first["warmup_inline"] == 0
+        assert first["restart_before"] is True
+        assert first["populate_with"] == "SET"
+        second = minimal_valid_config["test_groups"][1]["scenarios"][0]
+        assert second["test"] == "SET"
+        assert "populate_with" not in second
+
+    def test_duration_mode(self, minimal_valid_config):
+        from benchmark import compile_simple_config
+
         del minimal_valid_config["requests"]
-        runner = ClientRunner(
-            commit_id="abc",
-            config=minimal_valid_config,
-            cluster_mode=False,
-            tls_mode=False,
-            target_ip="127.0.0.1",
-            results_dir=Path("/tmp"),
-            valkey_path="/tmp/valkey",
-            valkey_benchmark_path="src/valkey-benchmark",
-        )
-        combos = runner._generate_combinations()
-        # requests defaults to [None]
-        assert combos[0][0] is None
+        minimal_valid_config["duration"] = 30
+        compile_simple_config(minimal_valid_config)
+
+        first = minimal_valid_config["test_groups"][0]["scenarios"][0]
+        assert first["duration"] == 30
+        assert "requests" not in first
+
+    def test_unsupported_command_dropped(self, minimal_valid_config):
+        from benchmark import compile_simple_config
+
+        minimal_valid_config["commands"] = ["GET", "XRANGE"]
+        compile_simple_config(minimal_valid_config)
+
+        tests = [
+            s["test"]
+            for g in minimal_valid_config["test_groups"]
+            for s in g["scenarios"]
+        ]
+        assert tests == ["GET"]
+
+    def test_groups_numbered_sequentially(self, minimal_valid_config):
+        from benchmark import compile_simple_config
+
+        compile_simple_config(minimal_valid_config)
+        assert [g["group"] for g in minimal_valid_config["test_groups"]] == [1, 2]
+
+    def test_compiled_config_passes_validation(self, minimal_valid_config):
+        from benchmark import compile_simple_config, validate_test_groups
+
+        compile_simple_config(minimal_valid_config)
+        validate_test_groups(minimal_valid_config)  # should not raise
 
 
 # ---------------------------------------------------------------------------
@@ -298,63 +375,136 @@ class TestGenerateCombinations:
 
 
 class TestCreateFailureMarker:
-    """Tests for ClientRunner._create_failure_marker."""
+    @staticmethod
+    def _processor(runner, commit_time="<TS>"):
+        return MetricsProcessor(
+            commit_id=runner.commit_id,
+            cluster_mode=runner.cluster_mode,
+            tls_mode=runner.tls_mode,
+            commit_time=commit_time,
+            io_threads=runner.io_threads,
+            benchmark_threads=runner.benchmark_threads,
+            architecture=runner.architecture,
+            repository=runner.repository,
+        )
 
-    def test_basic_marker(self, minimal_client_runner):
-        marker = minimal_client_runner._create_failure_marker(
+    def _marker(self, runner, **overrides):
+        fields = dict(
+            test_id="1_test1",
+            test_phase="write",
             group_id=1,
             scenario_id="test1",
-            scenario_type="write",
             error="timeout",
             command="SET foo bar",
-            timestamp="2024-01-01T00:00:00",
+            data_size=16,
+            pipeline=1,
+            clients=50,
+            requests=1000,
             config_set={"io_threads": 4},
         )
+        fields.update(overrides)
+        workload = {
+            "command": fields.pop("command"),
+            "data_size": fields.pop("data_size"),
+            "pipeline": fields.pop("pipeline"),
+            "clients": fields.pop("clients"),
+        }
+        return runner._create_failure_marker(
+            self._processor(runner), workload, **fields
+        )
+
+    def test_marker_base_identity_and_config_fields(self, minimal_client_runner):
+        marker = self._marker(minimal_client_runner, config_set={})
 
         assert marker["test_id"] == "1_test1"
         assert marker["test_phase"] == "write"
         assert marker["status"] == "failed"
         assert marker["error"] == "timeout"
         assert marker["command"] == "SET foo bar"
-        assert marker["timestamp"] == "2024-01-01T00:00:00"
-        assert marker["config_set"] == {"io_threads": 4}
-
-    def test_test_id_format(self, minimal_client_runner):
-        marker = minimal_client_runner._create_failure_marker(
-            group_id=5,
-            scenario_id="search_idx",
-            scenario_type="read",
-            error="err",
-            command="FT.SEARCH",
-            timestamp="ts",
-            config_set={},
-        )
-        assert marker["test_id"] == "5_search_idx"
-
-    def test_empty_config_set(self, minimal_client_runner):
-        marker = minimal_client_runner._create_failure_marker(
-            group_id=1,
-            scenario_id="s1",
-            scenario_type="test",
-            error="e",
-            command="c",
-            timestamp="t",
-            config_set={},
-        )
+        assert marker["group"] == 1
+        assert marker["scenario"] == "test1"
         assert marker["config_set"] == {}
+        assert marker["cluster_mode"] is False
+        assert marker["tls"] is False
+        assert marker["commit"] == "abc123"
+        assert marker["repository"] is None
+        assert marker["data_size"] == 16
+        assert marker["pipeline"] == 1
+        assert marker["clients"] == 50
+        assert marker["requests"] == 1000
+        assert marker["benchmark_mode"] == "requests"
 
-    def test_marker_includes_group_and_scenario(self, minimal_client_runner):
-        marker = minimal_client_runner._create_failure_marker(
-            group_id=7,
-            scenario_id="search_idx",
-            scenario_type="read",
-            error="boom",
-            command="FT.SEARCH",
-            timestamp="2024-01-01T00:00:00",
-            config_set={},
+    def test_marker_has_no_performance_fields_and_unset_axes_absent(
+        self, minimal_client_runner
+    ):
+        marker = self._marker(minimal_client_runner, config_set={})
+
+        for key in (
+            "rps",
+            "avg_latency_ms",
+            "min_latency_ms",
+            "p50_latency_ms",
+            "p95_latency_ms",
+            "p99_latency_ms",
+            "max_latency_ms",
+        ):
+            assert key not in marker
+        assert "io_threads" not in marker
+        assert "valkey_benchmark_threads" not in marker
+        assert "architecture" not in marker
+
+    def test_marker_module_and_optional_axis_attribution(self):
+        module_runner = ClientRunner(
+            commit_id="core_sha",
+            config={},
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp/test_results"),
+            valkey_path="/tmp/valkey",
+            valkey_benchmark_path="src/valkey-benchmark",
+            config_name="fts.json",
+            module_commit="mod_sha",
+            module_commit_timestamp="2026-01-01T00:00:00Z",
         )
-        assert marker["group"] == 7
-        assert marker["scenario"] == "search_idx"
+        module_marker = self._marker(module_runner, command="FT.SEARCH", config_set={})
+        assert module_marker["module_commit"] == "mod_sha"
+        assert module_marker["module_commit_timestamp"] == "2026-01-01T00:00:00Z"
+        assert module_marker["config_name"] == "fts.json"
+        assert module_marker["status"] == "failed"
+        assert "rps" not in module_marker
+
+        axis_runner = ClientRunner(
+            commit_id="c1",
+            config={"cluster_mode": True, "tls_mode": True},
+            cluster_mode=True,
+            tls_mode=True,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp/test_results"),
+            valkey_path="/tmp/valkey",
+            valkey_benchmark_path="src/valkey-benchmark",
+            io_threads=8,
+            benchmark_threads=2,
+            architecture="aarch64",
+            repository="valkey-io/valkey",
+        )
+        axis_marker = self._marker(
+            axis_runner,
+            test_id="2_b",
+            group_id=2,
+            scenario_id="b",
+            test_phase="read",
+            error="err",
+            command="GET",
+            config_set={"maxmemory": "1gb"},
+        )
+        assert axis_marker["cluster_mode"] is True
+        assert axis_marker["tls"] is True
+        assert axis_marker["io_threads"] == 8
+        assert axis_marker["valkey_benchmark_threads"] == 2
+        assert axis_marker["architecture"] == "aarch64"
+        assert axis_marker["repository"] == "valkey-io/valkey"
+        assert axis_marker["config_set"] == {"maxmemory": "1gb"}
 
 
 # ---------------------------------------------------------------------------
@@ -488,38 +638,74 @@ class TestIterateTestGroupsScenarios:
 
 
 # ---------------------------------------------------------------------------
-# _iterate_simple_scenarios — regression: simple (non-test_groups) format
-# must not pick up group_description / group_id / scenario fields.
+# Compiled basic-format scenarios through _iterate_test_groups_scenarios:
+# replaces the deleted _iterate_simple_scenarios path.
 # ---------------------------------------------------------------------------
 
 
-class TestIterateSimpleScenarios:
-    """Tests for ClientRunner._iterate_simple_scenarios.
+class TestIterateCompiledScenarios:
+    """Compiled basic-format groups flow through the unified iterator."""
 
-    The simple/core config format (commands + data_sizes + ... cartesian)
-    does not have groups or descriptions. These tests lock in that the
-    new group/scenario_description plumbing did not leak into the simple
-    path.
-    """
+    def _compiled_runner(self, config, cluster_mode=False):
+        from benchmark import compile_simple_config
 
-    def test_simple_yields_no_group_fields(self, minimal_client_runner):
-        items = list(minimal_client_runner._iterate_simple_scenarios())
+        compile_simple_config(config)
+        return ClientRunner(
+            commit_id="abc123",
+            config=config,
+            cluster_mode=cluster_mode,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp/test_results"),
+            valkey_path="/tmp/valkey",
+            valkey_benchmark_path="src/valkey-benchmark",
+        )
 
-        assert len(items) > 0
-        for item in items:
-            assert item["format"] == "simple"
-            assert "group_description" not in item
-            assert "group_id" not in item
-            assert "scenario" not in item
+    def test_compiled_scenarios_yielded_per_group(self, minimal_valid_config):
+        runner = self._compiled_runner(minimal_valid_config)
 
-    def test_simple_format_has_combination_keys(self, minimal_client_runner):
-        # Sanity: simple-format dicts carry the per-run combination keys
-        # (command, data_size, pipeline, ...) instead of group/scenario.
-        items = list(minimal_client_runner._iterate_simple_scenarios())
+        items = list(runner._iterate_test_groups_scenarios())
 
-        first = items[0]
-        for key in ("command", "data_size", "pipeline", "clients", "requests"):
-            assert key in first
+        assert len(items) == 2  # GET, SET
+        assert [i["scenario"]["test"] for i in items] == ["GET", "SET"]
+        assert [i["group_id"] for i in items] == [1, 2]
+        assert all(i["group_description"] is None for i in items)
+
+    def test_mset_mget_skipped_in_cluster_mode(self, minimal_valid_config):
+        minimal_valid_config["commands"] = ["MSET", "MGET", "SET"]
+        runner = self._compiled_runner(minimal_valid_config, cluster_mode=True)
+
+        items = list(runner._iterate_test_groups_scenarios())
+
+        assert [i["scenario"]["test"] for i in items] == ["SET"]
+
+    def test_mset_mget_kept_outside_cluster_mode(self, minimal_valid_config):
+        minimal_valid_config["commands"] = ["MSET", "MGET", "SET"]
+        runner = self._compiled_runner(minimal_valid_config, cluster_mode=False)
+
+        items = list(runner._iterate_test_groups_scenarios())
+
+        assert [i["scenario"]["test"] for i in items] == ["MSET", "MGET", "SET"]
+
+    def test_runs_repeat_each_compiled_group_consecutively(self, minimal_valid_config):
+        from benchmark import compile_simple_config
+
+        compile_simple_config(minimal_valid_config)
+        runner = ClientRunner(
+            commit_id="abc123",
+            config=minimal_valid_config,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp/test_results"),
+            valkey_path="/tmp/valkey",
+            valkey_benchmark_path="src/valkey-benchmark",
+            runs=2,
+        )
+
+        items = list(runner._iterate_test_groups_scenarios())
+
+        assert [i["scenario"]["test"] for i in items] == ["GET", "GET", "SET", "SET"]
 
 
 # ---------------------------------------------------------------------------
@@ -606,6 +792,76 @@ class TestNormalizeMixedConfigs:
         writes, _ = mixed_runner._normalize_mixed_configs(without_ce)
         assert "cluster_execution" not in writes[0]
 
+    def test_parent_data_size_propagates_to_subs(self, mixed_runner):
+        """A parent data_size reaches subs that do not set their own (piece 1).
+
+        Without this, _create_mixed_metric falls back to data_size=100 and every
+        mixed row misreports the payload.
+        """
+        scenario = {
+            "id": "j",
+            "data_size": 256,
+            "writes": [{"id": "w1", "command": "HSET k f v", "clients": 1}],
+            "reads": [{"id": "r1", "command": "FT.SEARCH idx q", "clients": 1}],
+        }
+        writes, reads = mixed_runner._normalize_mixed_configs(scenario)
+        assert writes[0]["data_size"] == 256
+        assert reads[0]["data_size"] == 256
+
+    def test_sub_scenario_data_size_overrides_parent(self, mixed_runner):
+        """A sub-scenario's own data_size is not replaced by the parent's."""
+        scenario = {
+            "id": "j",
+            "data_size": 256,
+            "writes": [
+                {"id": "w1", "command": "HSET k f v", "clients": 1, "data_size": 16}
+            ],
+            "reads": [{"id": "r1", "command": "FT.SEARCH idx q", "clients": 1}],
+        }
+        writes, reads = mixed_runner._normalize_mixed_configs(scenario)
+        assert writes[0]["data_size"] == 16  # override preserved
+        assert reads[0]["data_size"] == 256  # parent propagated
+
+    def test_no_parent_data_size_leaves_subs_untouched(self, mixed_runner):
+        """When the parent sets no data_size, subs gain none (FTS "j" is
+        byte-for-byte unchanged and still relies on the metric default)."""
+        scenario = {
+            "id": "j",
+            "writes": [{"id": "w1", "command": "HSET k f v", "clients": 1}],
+            "reads": [{"id": "r1", "command": "FT.SEARCH idx q", "clients": 1}],
+        }
+        writes, reads = mixed_runner._normalize_mixed_configs(scenario)
+        assert "data_size" not in writes[0]
+        assert "data_size" not in reads[0]
+
+    def test_parent_requests_propagates_to_subs(self, mixed_runner):
+        """Finding 1: a request-bounded parent's 'requests' reaches subs that do
+        not set their own; without it a predefined child hits the requires-
+        requests-or-duration guard and an arbitrary child falls back to 60s."""
+        scenario = {
+            "id": "j",
+            "requests": 500000,
+            "writes": [{"id": "w1", "command": "HSET k f v", "clients": 1}],
+            "reads": [{"id": "r1", "test": "GET", "clients": 1}],
+        }
+        writes, reads = mixed_runner._normalize_mixed_configs(scenario)
+        assert writes[0]["requests"] == 500000
+        assert reads[0]["requests"] == 500000
+
+    def test_sub_scenario_requests_overrides_parent(self, mixed_runner):
+        """A sub-scenario's own 'requests' is not replaced by the parent's."""
+        scenario = {
+            "id": "j",
+            "requests": 500000,
+            "writes": [
+                {"id": "w1", "command": "HSET k f v", "clients": 1, "requests": 10}
+            ],
+            "reads": [{"id": "r1", "command": "FT.SEARCH idx q", "clients": 1}],
+        }
+        writes, reads = mixed_runner._normalize_mixed_configs(scenario)
+        assert writes[0]["requests"] == 10  # override preserved
+        assert reads[0]["requests"] == 500000  # parent propagated
+
 
 class TestGetCpuForMixedProcess:
     """Tests for ClientRunner._get_cpu_for_mixed_process."""
@@ -636,7 +892,12 @@ class TestGetCpuForMixedProcess:
         assert runner._get_cpu_for_mixed_process(1) == "21"
 
     def test_first_range_as_single_core_parses_correctly(self, minimal_valid_config):
-        """When client_cpu_ranges[0] has no dash it still parses as an int."""
+        """When client_cpu_ranges[0] has no dash it still parses as an int.
+
+        The pool spans 30-33 (four dashless single-core entries) so two
+        two-core processes fit without overrunning it (see the finding-3 raise
+        test for the undersized case).
+        """
         cfg = {
             **minimal_valid_config,
             "cpu_allocation": {"cores_per_server": 1, "cores_per_client": 2},
@@ -650,9 +911,127 @@ class TestGetCpuForMixedProcess:
             results_dir=Path("/tmp"),
             valkey_path="/tmp",
         )
-        runner.client_cpu_ranges = ["30"]
+        runner.client_cpu_ranges = ["30", "31", "32", "33"]
         assert runner._get_cpu_for_mixed_process(0) == "30-31"
         assert runner._get_cpu_for_mixed_process(1) == "32-33"
+
+    def test_non_contiguous_range_parses(self, minimal_valid_config):
+        """Finding 2: a valid non-contiguous range (e.g. '10-11,20-21') must
+        parse via parse_core_range, not raise ValueError from split('-')."""
+        cfg = {
+            **minimal_valid_config,
+            "cpu_allocation": {"cores_per_server": 1, "cores_per_client": 2},
+        }
+        runner = ClientRunner(
+            commit_id="abc",
+            config=cfg,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp"),
+            valkey_path="/tmp",
+        )
+        runner.client_cpu_ranges = ["10-11,20-21"]
+        # start=10 (pool[0]), end=21 (pool[-1]); process 0 -> 10-11.
+        assert runner._get_cpu_for_mixed_process(0) == "10-11"
+
+    def test_undersized_pool_spills_and_warns(self, minimal_valid_config, caplog):
+        """A process whose cores fall past the pool end must spill onto extra
+        cores and warn (original behavior) rather than raise. Pool '10-11' (2
+        cores, cpc=2) fits one process; process 1 spills to '12-13'."""
+        cfg = {
+            **minimal_valid_config,
+            "cpu_allocation": {"cores_per_server": 1, "cores_per_client": 2},
+        }
+        runner = ClientRunner(
+            commit_id="abc",
+            config=cfg,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp"),
+            valkey_path="/tmp",
+        )
+        runner.client_cpu_ranges = ["10-11"]  # only 2 cores, one process fits
+        assert runner._get_cpu_for_mixed_process(0) == "10-11"
+        with caplog.at_level(logging.WARNING):
+            assert runner._get_cpu_for_mixed_process(1) == "12-13"
+        assert "exceeds the client CPU pool" in caplog.text
+
+    def test_non_contiguous_pool_allocates_only_real_cores(self, minimal_valid_config):
+        """Finding 1: the reported pool '10-11,20-21' (cores 12-13 absent) must
+        give process 1 the second real block '20-21', not the contiguous
+        '12-13' the old first..last arithmetic produced."""
+        cfg = {
+            **minimal_valid_config,
+            "cpu_allocation": {"cores_per_server": 1, "cores_per_client": 2},
+        }
+        runner = ClientRunner(
+            commit_id="abc",
+            config=cfg,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp"),
+            valkey_path="/tmp",
+        )
+        runner.client_cpu_ranges = ["10-11,20-21"]
+        assert runner._get_cpu_for_mixed_process(0) == "10-11"
+        assert runner._get_cpu_for_mixed_process(1) == "20-21"
+
+    def test_slice_running_out_mid_pool_spills_and_warns(
+        self, minimal_valid_config, caplog
+    ):
+        """Finding 1: when cores_per_client straddles a gap the last full block
+        exhausts the pool, so the next process spills past the last pool core
+        and warns. Pool [10,11,20,21], cores_per_client=3 -> process 0 gets the
+        real cores '10-11,20'; process 1 spills to '22-24' (past last core 21)
+        and warns instead of raising."""
+        cfg = {
+            **minimal_valid_config,
+            "cpu_allocation": {"cores_per_server": 1, "cores_per_client": 3},
+        }
+        runner = ClientRunner(
+            commit_id="abc",
+            config=cfg,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp"),
+            valkey_path="/tmp",
+        )
+        runner.client_cpu_ranges = ["10-11,20-21"]
+        assert runner._get_cpu_for_mixed_process(0) == "10-11,20"
+        with caplog.at_level(logging.WARNING):
+            assert runner._get_cpu_for_mixed_process(1) == "22-24"
+        assert "exceeds the client CPU pool" in caplog.text
+
+    def test_fts_shipped_config_spill_values(self, minimal_valid_config, caplog):
+        """Acceptance: the shipped fts-benchmarks-arm.json client pool (40 cores
+        at cores_per_client=8) must keep its original behavior -- processes 0-4
+        map to the in-pool blocks 40-47..72-79 and process 5 spills to 80-87."""
+        cfg = {
+            **minimal_valid_config,
+            "cpu_allocation": {"cores_per_server": 1, "cores_per_client": 8},
+        }
+        runner = ClientRunner(
+            commit_id="abc",
+            config=cfg,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp"),
+            valkey_path="/tmp",
+        )
+        runner.client_cpu_ranges = ["40-47", "48-55", "56-63", "64-71", "72-79"]
+        assert runner._get_cpu_for_mixed_process(0) == "40-47"
+        assert runner._get_cpu_for_mixed_process(1) == "48-55"
+        assert runner._get_cpu_for_mixed_process(2) == "56-63"
+        assert runner._get_cpu_for_mixed_process(3) == "64-71"
+        assert runner._get_cpu_for_mixed_process(4) == "72-79"
+        with caplog.at_level(logging.WARNING):
+            assert runner._get_cpu_for_mixed_process(5) == "80-87"
+        assert "exceeds the client CPU pool" in caplog.text
 
 
 def _popen_mock(stdout: str, returncode: int = 0):
@@ -663,20 +1042,7 @@ def _popen_mock(stdout: str, returncode: int = 0):
     return proc
 
 
-_MIXED_CSV = _make_csv(
-    [
-        {
-            "test": "HSET",
-            "rps": "1000.0",
-            "avg_latency_ms": "1.0",
-            "min_latency_ms": "0.5",
-            "p50_latency_ms": "1.0",
-            "p95_latency_ms": "1.5",
-            "p99_latency_ms": "2.0",
-            "max_latency_ms": "3.0",
-        }
-    ]
-)
+_MIXED_CSV = _make_csv([_metric_row("HSET")])
 
 
 class TestRunMixedWorkload:
@@ -696,14 +1062,8 @@ class TestRunMixedWorkload:
         with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
             mock_popen.side_effect = [_popen_mock(_MIXED_CSV) for _ in range(3)]
 
-            result = mixed_runner._run_mixed_workload(
-                mixed_scenario,
-                group_id=1,
-                config_set={},
-                metrics_processor=metrics_processor,
-                warmup_duration=0,
-                commit_time="2026-01-01T00:00:00Z",
-                scenario_id="j",
+            result = _run_mixed(
+                mixed_runner, mixed_scenario, metrics_processor=metrics_processor
             )
 
         assert result is not None and len(result) == 3
@@ -717,33 +1077,54 @@ class TestRunMixedWorkload:
 
         assert all(m.get("config_name") == "fts-mixed-test.json" for m in result)
 
-    def test_warmup_mode_still_spawns_processes_but_returns_no_metrics(
-        self, mixed_runner, mixed_scenario
+    @pytest.mark.parametrize("returncode", [0, 1])
+    def test_warmup_drains_processes_and_returns_no_metrics(
+        self, mixed_runner, mixed_scenario, returncode
     ):
-        """Warmup (metrics_processor=None) must still drain workload processes."""
+        """Warmup (metrics_processor=None) must still drain every child process
+        and record nothing -- even when the children fail (returncode=1), no
+        markers are produced."""
         with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
-            mock_popen.side_effect = [_popen_mock(_MIXED_CSV) for _ in range(3)]
+            mock_popen.side_effect = [
+                _popen_mock(_MIXED_CSV, returncode=returncode) for _ in range(3)
+            ]
 
-            result = mixed_runner._run_mixed_workload(
-                mixed_scenario,
-                group_id=1,
-                config_set={},
-                metrics_processor=None,
-                warmup_duration=0,
-                commit_time="2026-01-01T00:00:00Z",
-                scenario_id="j",
-            )
+            result = _run_mixed(mixed_runner, mixed_scenario, metrics_processor=None)
 
         assert mock_popen.call_count == 3
         assert result is None
 
-    def test_failed_process_produces_no_metric_for_that_sub_scenario(
+    def test_partial_launch_terminates_and_reaps_started_children(
         self, mixed_runner, mixed_scenario
     ):
-        """Non-zero exit for one process must not poison metrics for others."""
+        metrics_processor = MagicMock()
+        metrics_processor.build_base_metadata.side_effect = lambda *a, **kw: {}
+        started = _popen_mock("")
+        started.poll.return_value = None
+
+        with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
+            mock_popen.side_effect = [started, RuntimeError("second launch failed")]
+            result = _run_mixed(
+                mixed_runner, mixed_scenario, metrics_processor=metrics_processor
+            )
+
+        assert all(row["status"] == "failed" for row in result)
+        started.terminate.assert_called_once_with()
+        started.wait.assert_called_once_with(timeout=5)
+
+    def test_partial_failure_emits_marker_for_missing_child_only(
+        self, mixed_runner, mixed_scenario
+    ):
+        """Finding 1(b): a non-zero exit for one sub-scenario must emit a failure
+        marker for THAT child (so its healthy baseline is excluded instead of
+        rendering as a fabricated -100%) while the survivors keep their success
+        metrics."""
         # side_effect returns a fresh dict per call (see other test for why).
         metrics_processor = MagicMock()
         metrics_processor.create_metrics.side_effect = lambda *a, **kw: {"rps": 1000.0}
+        # The failed child's marker is built from the shared base-metadata
+        # assembly; make the mock return a real dict so the marker is a real row.
+        metrics_processor.build_base_metadata.side_effect = lambda *a, **kw: {}
 
         with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
             mock_popen.side_effect = [
@@ -752,33 +1133,65 @@ class TestRunMixedWorkload:
                 _popen_mock(_MIXED_CSV),  # r2 ok
             ]
 
-            result = mixed_runner._run_mixed_workload(
-                mixed_scenario,
-                group_id=1,
-                config_set={},
-                metrics_processor=metrics_processor,
-                warmup_duration=0,
-                commit_time="2026-01-01T00:00:00Z",
-                scenario_id="j",
+            result = _run_mixed(
+                mixed_runner, mixed_scenario, metrics_processor=metrics_processor
             )
 
-        test_ids = {m["test_id"] for m in result}
-        assert "1_j_write_w1" not in test_ids
-        assert "1_j_read_r1" in test_ids
-        assert "1_j_read_r2" in test_ids
+        by_status = {m["test_id"]: m.get("status") for m in result}
+        # The failed write child now has an honest failure marker...
+        assert by_status["1_j_write_w1"] == "failed"
+        # ...and the read survivors keep their success metrics.
+        assert by_status["1_j_read_r1"] == "success"
+        assert by_status["1_j_read_r2"] == "success"
+        # The marker carries the child's identity and no performance keys.
+        w_marker = next(m for m in result if m["test_id"] == "1_j_write_w1")
+        assert w_marker["test_phase"] == "mixed_write"
+        assert "rps" not in w_marker
+
+    @pytest.mark.parametrize(
+        "mode, err_substr",
+        [
+            ("all_fail", "produced no successful result"),  # Finding 1(a)
+            ("raise_mid_run", "launch exploded"),  # Finding 1(c)
+        ],
+    )
+    def test_total_failure_emits_marker_per_expected_child(
+        self, mixed_runner, mixed_scenario, mode, err_substr
+    ):
+        """Findings 1(a)/1(c): whether EVERY sub-scenario exits non-zero, or a
+        launch/aggregation exception blows up mid-run, the mixed path returns a
+        marker per expected child keyed by sub-scenario identity -- never None,
+        and never the old mis-keyed parent ``1_j`` marker -- so they pair with
+        the children they replaced."""
+        metrics_processor = MagicMock()
+        metrics_processor.create_metrics.side_effect = lambda *a, **kw: {"rps": 1000.0}
+        metrics_processor.build_base_metadata.side_effect = lambda *a, **kw: {}
+
+        with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
+            if mode == "raise_mid_run":
+                mock_popen.side_effect = RuntimeError("launch exploded")
+            else:
+                mock_popen.side_effect = [
+                    _popen_mock("", returncode=1) for _ in range(3)
+                ]
+
+            result = _run_mixed(
+                mixed_runner, mixed_scenario, metrics_processor=metrics_processor
+            )
+
+        assert result is not None
+        ids = {m["test_id"] for m in result}
+        assert ids == {"1_j_write_w1", "1_j_read_r1", "1_j_read_r2"}
+        # The mis-keyed parent marker must NOT appear.
+        assert "1_j" not in ids
+        assert all(m["status"] == "failed" for m in result)
+        assert all(err_substr in m["error"] for m in result)
 
     def test_empty_writes_and_reads_returns_none_without_spawning(self, mixed_runner):
         """A scenario with no sub-scenarios must not spawn anything."""
         scenario = {"id": "j", "duration": 60, "writes": [], "reads": []}
         with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
-            result = mixed_runner._run_mixed_workload(
-                scenario,
-                group_id=1,
-                config_set={},
-                metrics_processor=MagicMock(),
-                warmup_duration=0,
-                commit_time="2026-01-01T00:00:00Z",
-            )
+            result = _run_mixed(mixed_runner, scenario, metrics_processor=MagicMock())
 
         assert result is None
         assert mock_popen.call_count == 0
@@ -843,3 +1256,764 @@ class TestCreateMixedMetricRealProcessor:
         assert metric["test_id"] == "1_j_read_r1"
         assert metric["test_phase"] == "mixed_read"
         assert metric["rps"] == 1000.0
+
+    def test_test_subscenario_records_predefined_name(self, mixed_runner):
+        """A predefined ``test:`` sub-scenario no longer raises KeyError and
+        records the predefined name in the metric ``command`` field, matching
+        _build_scenario_metrics' aggregated-row convention (row["test"] is set
+        to the canonical test name by _aggregate_parallel_results)."""
+        real_processor = MetricsProcessor(
+            commit_id="abc123",
+            cluster_mode=False,
+            tls_mode=False,
+            commit_time="2026-01-01T00:00:00Z",
+        )
+        # Aggregated row: _aggregate_parallel_results stamps the canonical name.
+        row = _metric_row("SET")
+        sub_cfg = {"test": "SET", "clients": 10, "pipeline": 1}
+
+        metric = mixed_runner._create_mixed_metric(
+            row=row,
+            sub_cfg=sub_cfg,
+            parent_scenario={"duration": 60},
+            group_id=1,
+            scenario_id="j",
+            sub_id="w",
+            phase="write",
+            config_set={},
+            warmup_duration=0,
+            metrics_processor=real_processor,
+        )
+
+        assert metric is not None
+        assert metric["command"] == "SET"  # predefined name, not a KeyError
+        assert metric["test_id"] == "1_j_write_w"
+        assert metric["test_phase"] == "mixed_write"
+
+
+class TestBuildBenchmarkCommandPredefinedMixedSub:
+    """A predefined ``test:`` mixed sub-scenario SHALL be launched with ``-t
+    NAME`` -- the same predefined argv the rest of the framework emits."""
+
+    def test_predefined_sub_uses_dash_t(self, minimal_client_runner):
+        sub = {
+            "id": "w",
+            "test": "SET",
+            "clients": 10,
+            "pipeline": 2,
+            "data_size": 16,
+            "duration": 60,
+        }
+        argv = minimal_client_runner._build_benchmark_command(
+            scenario=sub, port=6379, seed_val=42
+        )
+        assert argv == [
+            "src/valkey-benchmark",
+            "-h",
+            "127.0.0.1",
+            "-p",
+            "6379",
+            "--duration",
+            "60",
+            "-r",
+            "1000",
+            "-d",
+            "16",
+            "-P",
+            "2",
+            "-c",
+            "10",
+            "-t",
+            "SET",
+            "--seed",
+            "42",
+            "--csv",
+        ]
+        # A predefined sub is a '-t' workload, never an arbitrary '--' command.
+        assert "--" not in argv
+
+
+class TestMixedDataSizeReachesMetric:
+    """A parent data_size reaches the mixed metric row."""
+
+    def test_parent_data_size_lands_in_create_metrics(self, mixed_runner):
+        scenario = {
+            "id": "j",
+            "type": "mixed",
+            "duration": 60,
+            "pipeline": 2,
+            "data_size": 256,
+            "writes": [{"id": "w1", "command": "HSET doc:x f v", "clients": 3}],
+            "reads": [{"id": "r1", "command": "FT.SEARCH idx q1", "clients": 5}],
+        }
+        metrics_processor = MagicMock()
+        metrics_processor.create_metrics.side_effect = lambda *a, **kw: {"rps": 1000.0}
+
+        with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
+            mock_popen.side_effect = [_popen_mock(_MIXED_CSV) for _ in range(2)]
+            result = _run_mixed(
+                mixed_runner, scenario, metrics_processor=metrics_processor
+            )
+
+        assert result is not None and len(result) == 2
+        # data_size is create_metrics' third positional arg.
+        seen_sizes = {
+            call.args[2] for call in metrics_processor.create_metrics.call_args_list
+        }
+        assert seen_sizes == {256}
+
+
+class TestMixedRequestsReachesMetric:
+    """A request-bounded mixed parent's request count reaches the metric row
+    (create_metrics' requests arg) instead of being dropped."""
+
+    def test_parent_requests_lands_in_create_metrics(self, mixed_runner):
+        scenario = {
+            "id": "j",
+            "type": "mixed",
+            "requests": 500000,
+            "pipeline": 2,
+            "writes": [{"id": "w1", "command": "HSET doc:x f v", "clients": 3}],
+            "reads": [{"id": "r1", "command": "FT.SEARCH idx q1", "clients": 5}],
+        }
+        metrics_processor = MagicMock()
+        metrics_processor.create_metrics.side_effect = lambda *a, **kw: {"rps": 1000.0}
+
+        with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
+            mock_popen.side_effect = [_popen_mock(_MIXED_CSV) for _ in range(2)]
+            result = _run_mixed(
+                mixed_runner, scenario, metrics_processor=metrics_processor
+            )
+
+        assert result is not None and len(result) == 2
+        # requests is create_metrics' sixth positional arg (index 5).
+        seen = {
+            call.args[5] for call in metrics_processor.create_metrics.call_args_list
+        }
+        assert seen == {500000}
+
+
+class TestMixedFailureMarkerRequests:
+    """Mixed failure markers carry the request count too, so a failed
+    request-bounded child records requests/benchmark_mode like a success row."""
+
+    def test_marker_carries_requests(self, mixed_runner):
+        scenario = {
+            "id": "j",
+            "type": "mixed",
+            "requests": 500000,
+            "pipeline": 2,
+            "writes": [{"id": "w1", "command": "HSET k f v", "clients": 3}],
+            "reads": [{"id": "r1", "command": "FT.SEARCH idx q", "clients": 5}],
+        }
+        real_processor = MetricsProcessor(
+            commit_id="abc123",
+            cluster_mode=False,
+            tls_mode=False,
+            commit_time="2026-01-01T00:00:00Z",
+        )
+        with patch("valkey_benchmark.subprocess.Popen") as mock_popen:
+            mock_popen.side_effect = [_popen_mock("", returncode=1) for _ in range(2)]
+            result = _run_mixed(
+                mixed_runner, scenario, metrics_processor=real_processor
+            )
+
+        assert result is not None and len(result) == 2
+        assert all(r["status"] == "failed" for r in result)
+        assert all(r["requests"] == 500000 for r in result)
+        assert all(r["benchmark_mode"] == "requests" for r in result)
+
+
+class TestWarmupWritesOnly:
+    """warmup_writes_only drops reads from the mixed warmup copy while the
+    default keeps both. Verified by capturing the scenario handed to
+    _run_mixed_workload from _run_scenario_warmup."""
+
+    @staticmethod
+    def _capture_warmup_scenario(runner, scenario):
+        captured = {}
+
+        def _fake_mixed(
+            warmup_scenario,
+            group_id,
+            config_set,
+            metrics_processor=None,
+            warmup_duration=0,
+            group_description=None,
+        ):
+            captured["scenario"] = warmup_scenario
+            return None
+
+        with patch.object(runner, "_run_mixed_workload", side_effect=_fake_mixed):
+            runner._run_scenario_warmup(scenario, group_id=1, config_set={})
+        return captured.get("scenario")
+
+    def _mixed(self, **extra):
+        return {
+            "id": "j",
+            "type": "mixed",
+            "warmup": 30,
+            "writes": [{"id": "w1", "command": "HSET k f v", "clients": 3}],
+            "reads": [
+                {"id": "r1", "command": "FT.SEARCH idx q1", "clients": 5},
+                {"id": "r2", "command": "FT.SEARCH idx q2", "clients": 5},
+            ],
+            **extra,
+        }
+
+    def test_opt_in_drops_reads(self, mixed_runner):
+        warmup = self._capture_warmup_scenario(
+            mixed_runner, self._mixed(warmup_writes_only=True)
+        )
+        assert warmup is not None
+        assert warmup["reads"] == []  # reads dropped
+        assert len(warmup["writes"]) == 1  # writes preserved
+
+    def test_default_keeps_both(self, mixed_runner):
+        warmup = self._capture_warmup_scenario(mixed_runner, self._mixed())
+        assert warmup is not None
+        assert len(warmup["reads"]) == 2  # today's behavior preserved
+        assert len(warmup["writes"]) == 1
+
+    def test_false_keeps_both(self, mixed_runner):
+        warmup = self._capture_warmup_scenario(
+            mixed_runner, self._mixed(warmup_writes_only=False)
+        )
+        assert warmup is not None
+        assert len(warmup["reads"]) == 2
+        assert len(warmup["writes"]) == 1
+
+    def test_opt_in_does_not_mutate_original_scenario(self, mixed_runner):
+        """The warmup transformation works on a copy; the real run still reads."""
+        scenario = self._mixed(warmup_writes_only=True)
+        self._capture_warmup_scenario(mixed_runner, scenario)
+        assert len(scenario["reads"]) == 2  # original untouched
+
+
+def _populate_scenario(**workload):
+    return {
+        "id": "s1",
+        "requests": 100,
+        "keyspacelen": 100,
+        "data_size": 64,
+        "pipeline": 1,
+        "clients": 1,
+        **workload,
+    }
+
+
+def _capture_scenario_commands(runner, scenario):
+    captured = []
+
+    def fake_run(command=None, *args, **kwargs):
+        captured.append(command)
+        return MagicMock()
+
+    with (
+        patch.object(runner, "_run", side_effect=fake_run),
+        patch("valkey_benchmark.random.randint", side_effect=[111, 222, 333]),
+    ):
+        _invoke_scenario(runner, scenario, metrics_processor=None)
+    return captured
+
+
+class TestPopulateWith:
+    @pytest.mark.parametrize(
+        "scenario, expected_tokens",
+        [
+            (_populate_scenario(test="GET", populate_with="SET"), ["-t", "SET"]),
+            (
+                _populate_scenario(
+                    command="GET key:__rand_int__",
+                    populate_with="SET key:__rand_int__ __data__",
+                ),
+                ["--", "SET", "key:__rand_int__", "__data__"],
+            ),
+        ],
+    )
+    def test_populate_argv_and_shared_seed(
+        self, minimal_client_runner, scenario, expected_tokens
+    ):
+        populate_cmd, main_cmd = _capture_scenario_commands(
+            minimal_client_runner, scenario
+        )
+
+        start = populate_cmd.index(expected_tokens[0])
+        assert populate_cmd[start : start + len(expected_tokens)] == expected_tokens
+        assert ("--" in populate_cmd) is (expected_tokens[0] == "--")
+        assert "--sequential" in populate_cmd
+        assert _seed_of(populate_cmd) == _seed_of(main_cmd) == "111"
+
+
+class TestPopulateWithNotInMetrics:
+    def test_populate_with_absent_from_metrics(self, minimal_client_runner):
+        real_processor = MetricsProcessor(
+            commit_id="abc123",
+            cluster_mode=False,
+            tls_mode=False,
+            commit_time="2026-01-01T00:00:00Z",
+        )
+
+        proc = MagicMock()
+        proc.stdout = _make_csv([_metric_row()])
+
+        metrics = minimal_client_runner._build_scenario_metrics(
+            _populate_scenario(test="GET", populate_with="SET"),
+            proc,
+            None,
+            group_id=1,
+            config_set={},
+            warmup_duration=0,
+            group_description=None,
+            metrics_processor=real_processor,
+        )
+
+        assert metrics is not None
+        assert "populate_with" not in metrics
+
+
+class TestRestartReappliesConfigSet:
+    @staticmethod
+    def _scenario(**extra):
+        return _populate_scenario(test="SET", **extra)
+
+    def _run(self, runner, scenario, config_set):
+        calls = []
+        with (
+            patch.object(runner, "_run", return_value=MagicMock()),
+            patch.object(
+                runner, "_restart_server", side_effect=lambda: calls.append("restart")
+            ),
+            patch.object(
+                runner, "_flush_database", side_effect=lambda: calls.append("flush")
+            ),
+            patch.object(
+                runner,
+                "_apply_config_set",
+                side_effect=lambda cs: calls.append(f"apply:{cs}"),
+            ),
+        ):
+            _invoke_scenario(
+                runner,
+                scenario,
+                metrics_processor=None,
+                config_set=config_set,
+            )
+        return calls
+
+    @pytest.mark.parametrize(
+        "extra, has_launcher, config_set, expected",
+        [
+            (
+                {ORIGIN_FIELD: ORIGIN_SIMPLE, "restart_before": True},
+                True,
+                {"appendonly": "no"},
+                ["restart", "apply:{'appendonly': 'no'}"],
+            ),
+            (
+                {"flush_before": True},
+                True,
+                {"appendonly": "no"},
+                ["restart", "apply:{'appendonly': 'no'}"],
+            ),
+            (
+                {"restart_before": True, "flush_before": True},
+                True,
+                {"appendonly": "no"},
+                ["restart", "apply:{'appendonly': 'no'}"],
+            ),
+            ({"restart_before": True}, True, {}, ["restart"]),
+            ({"restart_before": True}, False, {"appendonly": "no"}, ["flush"]),
+        ],
+    )
+    def test_restart_and_config_reapplication(
+        self, minimal_client_runner, extra, has_launcher, config_set, expected
+    ):
+        minimal_client_runner.server_launcher = MagicMock() if has_launcher else None
+        assert (
+            self._run(minimal_client_runner, self._scenario(**extra), config_set)
+            == expected
+        )
+
+
+FORBIDDEN_SIMPLE_KEYS = {
+    "test_id",
+    "test_phase",
+    "group",
+    "scenario",
+    "group_description",
+    "scenario_description",
+    "config_set",
+    "status",
+    "error",
+    "config_name",
+    "module_commit",
+    "module_commit_timestamp",
+    "dataset",
+}
+
+
+class TestRunSingleScenarioErrorPaths:
+    @staticmethod
+    def _command_scenario(**extra):
+        return _populate_scenario(type="write", command="SET", **extra)
+
+    @staticmethod
+    def _origin_simple(**extra):
+        return TestRunSingleScenarioErrorPaths._command_scenario(
+            **{ORIGIN_FIELD: ORIGIN_SIMPLE, **extra}
+        )
+
+    @staticmethod
+    def _invoke(runner, scenario, metrics_processor):
+        return _invoke_scenario(
+            runner,
+            scenario,
+            metrics_processor=metrics_processor,
+            config_set={"appendonly": "no"},
+        )
+
+    def test_origin_simple_no_results_returns_none(self, minimal_client_runner):
+        runner = minimal_client_runner
+        metrics_processor = MagicMock()
+
+        with (
+            patch.object(runner, "_build_benchmark_command", return_value=["vb"]),
+            patch.object(runner, "_run", return_value=None),
+        ):
+            result = self._invoke(runner, self._origin_simple(), metrics_processor)
+
+        assert result is None
+        metrics_processor.create_metrics.assert_not_called()
+
+    def test_handwritten_no_results_returns_failure_marker(self, minimal_client_runner):
+        runner = minimal_client_runner
+        metrics_processor = MetricsProcessor("abc123", False, False, "<TS>")
+
+        with (
+            patch.object(runner, "_build_benchmark_command", return_value=["vb"]),
+            patch.object(runner, "_run", return_value=None),
+        ):
+            result = self._invoke(runner, self._command_scenario(), metrics_processor)
+
+        assert isinstance(result, dict)
+        assert result["test_id"] == "1_s1"
+        assert result["test_phase"] == "write"
+        assert result["status"] == "failed"
+
+    def test_origin_simple_parse_error_returns_none(self, minimal_client_runner):
+        runner = minimal_client_runner
+        metrics_processor = MagicMock()
+
+        with (
+            patch.object(runner, "_build_benchmark_command", return_value=["vb"]),
+            patch.object(runner, "_run", return_value=MagicMock()),
+            patch.object(runner, "_parse_csv_row", side_effect=ValueError("bad csv")),
+        ):
+            result = self._invoke(runner, self._origin_simple(), metrics_processor)
+
+        assert result is None
+
+    def test_origin_simple_invocation_error_propagates(self, minimal_client_runner):
+        runner = minimal_client_runner
+        metrics_processor = MagicMock()
+
+        with (
+            patch.object(runner, "_build_benchmark_command", return_value=["vb"]),
+            patch.object(
+                runner, "_run", side_effect=RuntimeError("Command failed: vb")
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Command failed"):
+                self._invoke(runner, self._origin_simple(), metrics_processor)
+
+    def test_origin_simple_never_leaks_scenario_keys(self, minimal_client_runner):
+        runner = minimal_client_runner
+
+        success_processor = MagicMock()
+        success_processor.create_metrics.return_value = {
+            "rps": 1000.0,
+            "avg_latency_ms": 0.5,
+        }
+        with (
+            patch.object(runner, "_build_benchmark_command", return_value=["vb"]),
+            patch.object(runner, "_run", return_value=MagicMock()),
+            patch.object(
+                runner, "_parse_csv_row", return_value={"test": "SET", "rps": "1000"}
+            ),
+        ):
+            success = self._invoke(runner, self._origin_simple(), success_processor)
+
+        assert isinstance(success, dict)
+        assert FORBIDDEN_SIMPLE_KEYS.isdisjoint(success)
+
+        with (
+            patch.object(runner, "_build_benchmark_command", return_value=["vb"]),
+            patch.object(runner, "_run", return_value=None),
+        ):
+            no_results = self._invoke(runner, self._origin_simple(), MagicMock())
+
+        assert no_results is None
+
+    def test_handwritten_populate_failure_returns_failure_marker(
+        self, minimal_client_runner
+    ):
+        runner = minimal_client_runner
+        metrics_processor = MetricsProcessor("abc123", False, False, "<TS>")
+        scenario = self._command_scenario(populate_with="SET key:__rand_int__ v")
+
+        with patch.object(
+            runner,
+            "_populate_scenario_keyspace",
+            side_effect=RuntimeError("populate boom"),
+        ):
+            result = self._invoke(runner, scenario, metrics_processor)
+
+        assert isinstance(result, dict)
+        assert result["status"] == "failed"
+        assert result["test_id"] == "1_s1"
+        assert "populate boom" in result["error"]
+
+    def test_origin_simple_populate_failure_propagates(self, minimal_client_runner):
+        runner = minimal_client_runner
+        scenario = self._origin_simple(populate_with="SET")
+
+        with patch.object(
+            runner,
+            "_populate_scenario_keyspace",
+            side_effect=RuntimeError("populate boom"),
+        ):
+            with pytest.raises(RuntimeError, match="populate boom"):
+                self._invoke(runner, scenario, MagicMock())
+
+    def test_successful_populate_runs_before_main_invocation(
+        self, minimal_client_runner
+    ):
+        runner = minimal_client_runner
+        metrics_processor = MagicMock()
+        scenario = self._command_scenario(populate_with="SET key:__rand_int__ v")
+
+        calls = []
+
+        def record_populate(*args, **kwargs):
+            calls.append("populate")
+
+        def record_main(*args, **kwargs):
+            calls.append("main")
+            return MagicMock(), None
+
+        with (
+            patch.object(
+                runner, "_populate_scenario_keyspace", side_effect=record_populate
+            ),
+            patch.object(runner, "_execute_benchmark_run", side_effect=record_main),
+            patch.object(runner, "_build_scenario_metrics", return_value={"rps": 1.0}),
+        ):
+            result = self._invoke(runner, scenario, metrics_processor)
+
+        assert calls == ["populate", "main"]
+        assert result == {"rps": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# Parallel execution of ``test:`` scenarios (P1-3)
+# ---------------------------------------------------------------------------
+
+
+def _cme_parallel_runner(minimal_client_runner, nodes=2):
+    runner = minimal_client_runner
+    runner.cluster_mode = True
+    runner.config["cluster_nodes"] = nodes
+    ports = [6379 + i for i in range(nodes)]
+    runner.config["cluster_ports"] = ports
+    runner.client_cpu_ranges = [str(i) for i in range(nodes)]
+    return runner
+
+
+class TestAggregateParallelTestScenario:
+    def _result(self, test="GET", rps="100000"):
+        return (_make_csv([_metric_row(test, rps)]), "", 6379)
+
+    @pytest.mark.parametrize("workload", [{"test": "GET"}, {"command": "SET key v"}])
+    def test_labels_from_workload_key(self, minimal_client_runner, workload):
+        scenario = {"id": "a", "cluster_execution": "parallel", **workload}
+        agg = minimal_client_runner._aggregate_parallel_results(
+            [self._result(test="SET")], scenario
+        )
+
+        assert agg["test"] == next(iter(workload.values()))
+        assert float(agg["rps"]) == pytest.approx(100000.0)
+
+
+class TestBuildScenarioMetricsAggregatedRow:
+    @staticmethod
+    def _aggregated_row(test="GET"):
+        return _metric_row(test, "100000")
+
+    @pytest.mark.parametrize("workload", [{"test": "GET"}, {"command": "GET key"}])
+    def test_parallel_scenario_uses_aggregated_row(
+        self, minimal_client_runner, workload
+    ):
+        runner = minimal_client_runner
+        metrics_processor = MagicMock()
+        metrics_processor.create_metrics.return_value = {"rps": 100000.0}
+        scenario = {
+            "id": "a",
+            "type": "read",
+            "cluster_execution": "parallel",
+            **workload,
+        }
+        label = next(iter(workload.values()))
+        aggregated = self._aggregated_row(label)
+
+        result = runner._build_scenario_metrics(
+            scenario,
+            None,
+            aggregated,
+            group_id=1,
+            config_set={},
+            warmup_duration=0,
+            group_description=None,
+            metrics_processor=metrics_processor,
+        )
+
+        assert result is not None
+        assert result["status"] == "success"
+        assert result["test_id"] == "1_a"
+        metrics_processor.create_metrics.assert_called_once()
+        call = metrics_processor.create_metrics.call_args
+        assert call.args[:2] == (aggregated, label)
+
+
+class TestParallelSeedSharing:
+    @staticmethod
+    def _seeds(commands):
+        return [cmd[cmd.index("--seed") + 1] for cmd in commands if "--seed" in cmd]
+
+    def test_populate_and_parallel_readers_share_one_seed(self, minimal_client_runner):
+        runner = _cme_parallel_runner(minimal_client_runner, nodes=2)
+        scenario = _populate_scenario(
+            id="a",
+            type="read",
+            test="GET",
+            populate_with="SET",
+            cluster_execution="parallel",
+        )
+
+        built = []
+        real_build = runner._build_benchmark_command
+
+        def spy_build(*args, **kwargs):
+            cmd = real_build(*args, **kwargs)
+            built.append(cmd)
+            return cmd
+
+        with (
+            patch.object(runner, "_build_benchmark_command", side_effect=spy_build),
+            patch.object(runner, "_run", return_value=MagicMock()),
+            patch(
+                "valkey_benchmark.subprocess.Popen",
+                return_value=_popen_mock(_MIXED_CSV),
+            ),
+            patch("valkey_benchmark.random.randint", side_effect=[999, 11, 22, 33, 44]),
+        ):
+            _invoke_scenario(runner, scenario, metrics_processor=None)
+
+        seeds = self._seeds(built)
+        assert len(seeds) == 3
+        assert seeds == ["999", "999", "999"]
+
+    def test_parallel_without_populate_keeps_draw_count(self, minimal_client_runner):
+        runner = _cme_parallel_runner(minimal_client_runner, nodes=2)
+        scenario = _populate_scenario(
+            id="a", type="read", test="GET", cluster_execution="parallel"
+        )
+
+        with (
+            patch(
+                "valkey_benchmark.subprocess.Popen",
+                return_value=_popen_mock(_MIXED_CSV),
+            ),
+            patch(
+                "valkey_benchmark.random.randint", side_effect=[11, 22, 33, 44]
+            ) as randint,
+        ):
+            _invoke_scenario(runner, scenario, metrics_processor=None)
+
+        assert randint.call_count == 2
+
+
+class TestProfilingAlwaysStopped:
+    @staticmethod
+    def _invoke(runner, scenario, profiler, metrics_processor):
+        return _invoke_scenario(
+            runner,
+            scenario,
+            profiler=profiler,
+            metrics_processor=metrics_processor,
+        )
+
+    @staticmethod
+    def _command_scenario(**extra):
+        return _populate_scenario(type="write", command="SET", **extra)
+
+    @pytest.mark.parametrize("origin_simple", [False, True])
+    def test_stops_on_invocation_error(self, minimal_client_runner, origin_simple):
+        runner = minimal_client_runner
+        profiler = MagicMock()
+        scenario = self._command_scenario(
+            **({ORIGIN_FIELD: ORIGIN_SIMPLE} if origin_simple else {})
+        )
+        processor = MetricsProcessor("abc123", False, False, "<TS>")
+        with (
+            patch.object(
+                runner, "_resolve_effective_profiling", return_value={"enabled": True}
+            ),
+            patch.object(
+                runner,
+                "_execute_benchmark_run",
+                side_effect=RuntimeError("invocation boom"),
+            ),
+        ):
+            if origin_simple:
+                with pytest.raises(RuntimeError, match="invocation boom"):
+                    self._invoke(runner, scenario, profiler, processor)
+            else:
+                result = self._invoke(runner, scenario, profiler, processor)
+                assert result["status"] == "failed"
+
+        assert profiler.stop_profiling.call_count == 1
+
+    @pytest.mark.parametrize(
+        "scenario, method, method_result, expected",
+        [
+            (
+                _populate_scenario(type="write", command="SET"),
+                "_execute_benchmark_run",
+                (MagicMock(), None),
+                {"rps": 1.0},
+            ),
+            (
+                {"id": "s1", "type": "mixed", "warmup": 0},
+                "_run_mixed_workload",
+                [{"rps": 1.0}],
+                [{"rps": 1.0}],
+            ),
+        ],
+    )
+    def test_stops_once_on_success(
+        self, minimal_client_runner, scenario, method, method_result, expected
+    ):
+        runner = minimal_client_runner
+        profiler = MagicMock()
+        with (
+            patch.object(
+                runner, "_resolve_effective_profiling", return_value={"enabled": True}
+            ),
+            patch.object(runner, method, return_value=method_result),
+            patch.object(runner, "_build_scenario_metrics", return_value={"rps": 1.0}),
+        ):
+            result = self._invoke(runner, scenario, profiler, MagicMock())
+
+        assert result == expected
+        assert profiler.stop_profiling.call_count == 1

--- a/tests/test_commit_id_passthrough.py
+++ b/tests/test_commit_id_passthrough.py
@@ -59,7 +59,6 @@ class TestCommitIdPassthrough:
             valkey_dir=tmp_path,
             commit_id="abc123def456",
             module_path=None,
-            uses_test_groups=False,
             architecture="x86_64",
             client_cpu_ranges=None,
         )
@@ -82,7 +81,6 @@ class TestCommitIdPassthrough:
             valkey_dir=tmp_path,
             commit_id="9a29b97a8e80e07e6db1758f8c74bfd5db2becc6",
             module_path=None,
-            uses_test_groups=False,
             architecture="x86_64",
             client_cpu_ranges=None,
         )

--- a/tests/test_compare_benchmark.py
+++ b/tests/test_compare_benchmark.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from valkey_benchmark import ClientRunner
+from process_metrics import MetricsProcessor
+
 from utils.compare_benchmark_results import (
     calculate_mean,
     calculate_stdev,
@@ -11,6 +14,7 @@ from utils.compare_benchmark_results import (
     average_multiple_runs,
     discover_config_keys,
     group_by_command,
+    group_by_static_configuration,
     calculate_prediction_interval_percentage,
     calculate_confidence_interval_percentage,
     calculate_percent_change_with_ci,
@@ -19,6 +23,9 @@ from utils.compare_benchmark_results import (
     create_config_sort_key,
     summarize_benchmark_results,
     create_comparison_table_data,
+    format_comparison_report,
+    collect_failed_scenarios,
+    _scenario_identity,
     _format_with_sig_figs,
     _format_stats_only,
     _format_percent_change,
@@ -26,6 +33,161 @@ from utils.compare_benchmark_results import (
     _get_significance_indicator,
     CONFIDENCE_PERCENT,
 )
+
+
+def _row_stamper(module_commit=None, module_commit_timestamp=None, config_name=None):
+    """Minimal runner shell for exercising the real row-stamping methods."""
+    runner = object.__new__(ClientRunner)
+    runner.module_commit = module_commit
+    runner.module_commit_timestamp = module_commit_timestamp
+    runner.config_name = config_name
+    return runner
+
+
+def _scenario_parts(test_id):
+    group, _, scenario = str(test_id).partition("_")
+    return (int(group) if group.isdigit() else 1), scenario or str(test_id)
+
+
+def real_failure_row(
+    test_id,
+    error,
+    *,
+    command="HSET",
+    phase="write",
+    config_set=None,
+    cluster_mode=False,
+    tls_mode=False,
+    io_threads=4,
+    data_size=16,
+    pipeline=1,
+    clients=50,
+    requests=1000,
+    duration=None,
+    commit="new123",
+    repository=None,
+    module_commit=None,
+    module_commit_timestamp=None,
+    config_name=None,
+    **extra,
+):
+    """Build a failure row through the production marker path."""
+    group_id, scenario_id = _scenario_parts(test_id)
+    runner = _row_stamper(
+        module_commit=module_commit,
+        module_commit_timestamp=module_commit_timestamp,
+        config_name=config_name,
+    )
+    processor = MetricsProcessor(
+        commit_id=commit,
+        cluster_mode=cluster_mode,
+        tls_mode=tls_mode,
+        commit_time="<TS>",
+        io_threads=io_threads,
+        repository=repository,
+    )
+    marker = runner._create_failure_marker(
+        processor,
+        {
+            "command": command,
+            "data_size": data_size,
+            "pipeline": pipeline,
+            "clients": clients,
+            "duration": duration,
+        },
+        test_id=f"{group_id}_{scenario_id}",
+        test_phase=phase,
+        group_id=group_id,
+        scenario_id=scenario_id,
+        error=error,
+        requests=requests,
+        config_set=config_set,
+    )
+    marker.update(extra)
+    return marker
+
+
+def real_success_row(
+    *,
+    test_id=None,
+    test_phase="write",
+    command="GET",
+    pipeline=1,
+    io_threads=4,
+    data_size=16,
+    clients=50,
+    rps=100000.0,
+    avg_latency_ms=0.5,
+    p50_latency_ms=0.4,
+    p95_latency_ms=0.8,
+    p99_latency_ms=1.2,
+    config_set=None,
+    cluster_mode=False,
+    tls_mode=False,
+    commit="base123",
+    repository=None,
+    **extra,
+):
+    """Build a success row through the production metrics path."""
+    proc = MetricsProcessor(
+        commit_id=commit,
+        cluster_mode=cluster_mode,
+        tls_mode=tls_mode,
+        commit_time="<TS>",
+        io_threads=io_threads,
+        repository=repository,
+    )
+    bench = {
+        "rps": str(rps),
+        "avg_latency_ms": str(avg_latency_ms),
+        "min_latency_ms": "0.1",
+        "p50_latency_ms": str(p50_latency_ms),
+        "p95_latency_ms": str(p95_latency_ms),
+        "p99_latency_ms": str(p99_latency_ms),
+        "max_latency_ms": "5.0",
+    }
+    row = proc.create_metrics(
+        bench, command, data_size, pipeline, clients, requests=1000
+    )
+    if test_id is not None:
+        group_id, scenario_id = _scenario_parts(test_id)
+        row["status"] = "success"
+        _row_stamper()._apply_row_metadata(
+            row,
+            test_id=test_id,
+            test_phase=test_phase,
+            group_id=group_id,
+            scenario_id=scenario_id,
+            config_set=config_set or {},
+        )
+    row.update(extra)
+    return row
+
+
+def _comparison(baseline, new, metrics_filter="all"):
+    """Return failed descriptors, comparison groups, and the rendered report."""
+    failed = collect_failed_scenarios(baseline, new, metrics_filter)
+    result = create_comparison_table_data(baseline, new, metrics_filter)
+    groups, baseline_version, new_version, baseline_repo, new_repo = result
+    report = format_comparison_report(
+        groups,
+        baseline_version,
+        new_version,
+        baseline_repo,
+        new_repo,
+        failed_scenarios=failed,
+    )
+    return failed, groups, report
+
+
+def _metric_rows(groups, metric="rps"):
+    return [
+        row
+        for group in groups
+        for row in group["table_rows"]
+        if row["metric"] == metric
+    ]
+
 
 # --- calculate_mean ---
 
@@ -317,6 +479,75 @@ class TestDiscoverConfigKeys:
         assert "rps_pi_lower" not in keys
         assert "rps_pi_upper" not in keys
 
+    def test_excludes_only_volatile_env_field(self):
+        # env_-prefixed reproducibility metadata (upstream PR #55) is split by
+        # classification, NOT by a blanket prefix rule: only the VOLATILE live
+        # reading (env_cpu_freq_mhz_at_setup) is excluded so same-host runs still
+        # pair, while STABLE compatibility fields (cpu_model, kernel_version, ...)
+        # participate in the signature so incompatible environments do not
+        # silently compare.
+        data = [
+            {
+                "command": "GET",
+                "pipeline": 1,
+                "env_cpu_model": "golden-cpu",
+                "env_cpu_freq_mhz_at_setup": 3200,
+                "env_kernel_version": "golden-kernel",
+            }
+        ]
+        keys = discover_config_keys(data)
+        assert "command" in keys
+        assert "pipeline" in keys
+        # Volatile live reading is excluded.
+        assert "env_cpu_freq_mhz_at_setup" not in keys
+        # Stable compatibility fields participate.
+        assert "env_cpu_model" in keys
+        assert "env_kernel_version" in keys
+
+    def test_unknown_env_field_defaults_to_participating(self):
+        # A future/unknown env_ field not enumerated in _VOLATILE_ENV_FIELDS
+        # defaults to the STABLE side (participates) -- the safer direction, so a
+        # newly-added environment axis is never silently ignored.
+        data = [{"command": "GET", "env_some_future_knob": "x"}]
+        keys = discover_config_keys(data)
+        assert "env_some_future_knob" in keys
+
+    def test_env_only_difference_yields_matching_signatures(self):
+        # Two datasets identical except for a live env_ reading (e.g. CPU
+        # frequency sampled at setup) must group under the SAME static config
+        # signature, so group_by_static_configuration finds a shared group and
+        # the comparison table is non-empty.
+        baseline = [
+            {
+                "command": "GET",
+                "pipeline": 1,
+                "io_threads": 4,
+                "clients": 50,
+                "data_size": 16,
+                "rps": 100000.0,
+                "env_cpu_freq_mhz_at_setup": 3200,
+            }
+        ]
+        new = [
+            {
+                "command": "GET",
+                "pipeline": 1,
+                "io_threads": 4,
+                "clients": 50,
+                "data_size": 16,
+                "rps": 101000.0,
+                "env_cpu_freq_mhz_at_setup": 3105,
+            }
+        ]
+
+        baseline_groups = group_by_static_configuration(baseline)
+        new_groups = group_by_static_configuration(new)
+        shared = set(baseline_groups) & set(new_groups)
+        assert len(shared) == 1, (
+            "datasets differing only in an env_ value must share a config "
+            f"signature; baseline={list(baseline_groups)} new={list(new_groups)}"
+        )
+
 
 # --- group_by_command ---
 
@@ -437,18 +668,42 @@ class TestExtractVersionIdentifier:
 
 class TestCreateConfigSignature:
     def test_returns_tuple_of_values(self):
+        # A trailing frozen config_set component (None when absent) is always
+        # appended so distinct config_sets never collapse into one group.
         item = {"command": "GET", "pipeline": 1, "data_size": 64}
         keys = ["command", "pipeline", "data_size"]
-        assert create_config_signature(item, keys) == ("GET", 1, 64)
+        assert create_config_signature(item, keys) == ("GET", 1, 64, None)
 
     def test_missing_keys_return_none(self):
         item = {"command": "GET"}
         keys = ["command", "missing_key"]
-        assert create_config_signature(item, keys) == ("GET", None)
+        assert create_config_signature(item, keys) == ("GET", None, None)
 
-    def test_empty_keys_returns_empty_tuple(self):
+    def test_empty_keys_returns_config_set_component_only(self):
         item = {"command": "GET"}
-        assert create_config_signature(item, []) == ()
+        # No config keys -> just the trailing (None) config_set component.
+        assert create_config_signature(item, []) == (None,)
+
+    def test_config_set_frozen_into_trailing_component(self):
+        # A config_set dict is frozen into a stable, order-independent component
+        # so two distinct config_sets produce two distinct signatures.
+        keys = ["command"]
+        sig_1gb = create_config_signature(
+            {"command": "GET", "config_set": {"maxmemory": "1gb"}}, keys
+        )
+        sig_4gb = create_config_signature(
+            {"command": "GET", "config_set": {"maxmemory": "4gb"}}, keys
+        )
+        assert sig_1gb != sig_4gb
+        assert sig_1gb == ("GET", (("maxmemory", "1gb"),))
+
+    def test_empty_config_set_matches_absent(self):
+        # An empty config_set collapses to the same None component as an absent
+        # one, so single-config runs key exactly as before.
+        keys = ["command"]
+        assert create_config_signature(
+            {"command": "GET", "config_set": {}}, keys
+        ) == create_config_signature({"command": "GET"}, keys)
 
 
 # --- create_config_sort_key ---
@@ -868,3 +1123,855 @@ class TestComparisonPipeline:
             )
             == "❌"
         )
+
+
+# --- Union key discovery + failed-scenario reporting ---
+
+
+class TestUnionKeyDiscoveryAndFailedScenarios:
+    def _row(self, **overrides):
+        return real_success_row(**overrides)
+
+    def _failure(
+        self,
+        test_id,
+        error,
+        side_commit,
+        phase="write",
+        command="HSET",
+        config_set=None,
+        cluster_mode=False,
+        **extra,
+    ):
+        return real_failure_row(
+            test_id,
+            error,
+            phase=phase,
+            command=command,
+            config_set=config_set,
+            cluster_mode=cluster_mode,
+            commit=side_commit,
+            **extra,
+        )
+
+    def test_union_key_discovery_matches_across_extra_field(self):
+        baseline = [
+            self._row(test_id="1_a"),
+            self._row(test_id="1_b", command="SET"),
+        ]
+        new = [
+            self._row(test_id="1_a", extra_field="only-in-new"),
+            self._row(test_id="1_b", command="SET"),
+        ]
+
+        per_dataset_shared = set(group_by_static_configuration(baseline)) & set(
+            group_by_static_configuration(new)
+        )
+        assert len(per_dataset_shared) == 0
+
+        shared_keys = discover_config_keys(baseline + new)
+        union_shared = set(group_by_static_configuration(baseline, shared_keys)) & set(
+            group_by_static_configuration(new, shared_keys)
+        )
+        assert len(union_shared) == 1
+
+    def test_union_keys_survive_metrics_schema_drift_through_pipeline(self):
+        baseline = [
+            self._row(test_id="1_a", rps=100000.0),
+            self._row(test_id="1_b", rps=100000.0),
+        ]
+        new = [
+            self._row(test_id="1_a", rps=120000.0, commit="new123"),
+            self._row(
+                test_id="1_b", rps=130000.0, commit="new123", keyspacelen=1000000
+            ),
+        ]
+
+        assert "keyspacelen" not in discover_config_keys(baseline)
+        assert "keyspacelen" in discover_config_keys(new)
+
+        groups, *_ = create_comparison_table_data(baseline, new)
+        matched = [
+            r
+            for g in groups
+            if g["config_dict"].get("test_id") == "1_a"
+            for r in g["table_rows"]
+            if r["metric"] == "rps"
+        ]
+        assert len(matched) == 1
+        assert matched[0]["baseline_value"] == pytest.approx(100000.0)
+        assert matched[0]["new_value"] == pytest.approx(120000.0)
+        assert matched[0]["change"] == pytest.approx(20.0)
+
+        assert len(groups) == 3
+
+    def test_failed_scenario_pairs_across_one_sided_schema_field(self):
+        baseline = [self._row(test_id="1_a", rps=123456.0)]
+        new = [self._failure("1_a", "client failed", "new123", keyspacelen=1000000)]
+
+        failed, groups, report = _comparison(baseline, new, "rps")
+
+        assert failed[0]["counterpart_present"] is True
+        assert failed[0]["counterpart_value"] == pytest.approx(123456.0)
+        assert _metric_rows(groups) == []
+        assert "123K rps" in report
+        assert "-100.0%" not in report
+
+    def test_schema_fallback_refuses_ambiguous_one_to_many_match(self):
+        baseline = [self._row(test_id="1_a", rps=123456.0)]
+        new = [
+            self._failure("1_a", "client failed", "new123", keyspacelen=1000),
+            self._row(test_id="1_a", commit="new123", keyspacelen=2000, rps=200000.0),
+        ]
+
+        failed = collect_failed_scenarios(baseline, new, "rps")
+
+        assert failed[0]["counterpart_present"] is False
+        assert failed[0]["counterpart_value"] is None
+
+    def test_failed_scenario_does_not_poison_healthy_scenario(self):
+        baseline = [
+            self._row(test_id="1_a", command="HSET"),
+            self._row(test_id="1_b", command="FT.SEARCH"),
+        ]
+        new = [
+            self._failure("1_a", "No results", "new123"),
+            self._row(test_id="1_b", command="FT.SEARCH", commit="new123"),
+        ]
+
+        groups, *_ = create_comparison_table_data(baseline, new)
+
+        assert len(groups) == 1
+        rps_rows = _metric_rows(groups)
+        assert len(rps_rows) == 1
+        assert rps_rows[0]["baseline_value"] == pytest.approx(100000.0)
+        assert rps_rows[0]["new_value"] == pytest.approx(100000.0)
+        assert rps_rows[0]["change"] == pytest.approx(0.0)
+
+    def test_failed_in_new_labeled_not_regression(self):
+        baseline = [
+            self._row(test_id="1_a", command="HSET"),
+            self._row(test_id="1_b", command="FT.SEARCH"),
+        ]
+        new = [
+            self._failure("1_a", "boom benchmark crashed", "new123"),
+            self._row(test_id="1_b", command="FT.SEARCH", commit="new123"),
+        ]
+
+        _, _, report = _comparison(baseline, new)
+
+        assert "failed scenario" in report.lower()
+        assert "1_a" in report
+        assert "boom benchmark crashed" in report
+        assert (
+            "| Scenario | Phase | Command | ` base123 ` | ` new123 ` | Error |"
+            in report
+        )
+        assert "100K rps" in report
+        assert "**FAILED**" in report
+        assert "-100.0%" not in report
+
+    def test_failed_in_baseline_labeled_not_phantom_improvement(self):
+        baseline = [
+            self._failure("1_a", "baseline oom", "base123"),
+            self._row(test_id="1_b", command="FT.SEARCH"),
+        ]
+        new = [
+            self._row(test_id="1_a", command="HSET", commit="new123"),
+            self._row(test_id="1_b", command="FT.SEARCH", commit="new123"),
+        ]
+
+        _, groups, report = _comparison(baseline, new)
+
+        assert "1_a" in report
+        assert "baseline oom" in report
+        assert "100K rps" in report
+        assert "**FAILED**" in report
+        assert "-100.0%" not in report
+
+        assert len(groups) == 1
+        rps_rows = _metric_rows(groups)
+        assert len(rps_rows) == 1
+        assert rps_rows[0]["change"] == pytest.approx(0.0)
+
+    def test_normal_comparison_unchanged_no_failures(self):
+        baseline = [
+            self._row(command="GET", rps=100000.0),
+            self._row(command="SET", rps=80000.0),
+        ]
+        new = [
+            self._row(command="GET", rps=120000.0, commit="new123"),
+            self._row(command="SET", rps=88000.0, commit="new123"),
+        ]
+
+        failed, groups, report = _comparison(baseline, new)
+        assert failed == []
+        assert len(groups) == 1
+
+        rows = groups[0]["table_rows"]
+        get_rps = next(
+            r for r in rows if r["command"] == "GET" and r["metric"] == "rps"
+        )
+        set_rps = next(
+            r for r in rows if r["command"] == "SET" and r["metric"] == "rps"
+        )
+        assert get_rps["change"] == pytest.approx(20.0)
+        assert set_rps["change"] == pytest.approx(10.0)
+
+        assert "failed scenario" not in report.lower()
+
+    def test_failed_in_new_captures_baseline_value(self):
+        baseline = [self._row(test_id="1_a", command="HSET", rps=123456.0)]
+        new = [self._failure("1_a", "boom", "new123")]
+
+        failed, _, report = _comparison(baseline, new)
+        assert len(failed) == 1
+        entry = failed[0]
+        assert entry["side"] == "new"
+        assert entry["counterpart_present"] is True
+        assert entry["counterpart_value"] == pytest.approx(123456.0)
+        assert entry["metric_label"] == "rps"
+
+        assert "123K rps" in report
+        assert "**FAILED**" in report
+
+    def test_failed_in_baseline_captures_new_value(self):
+        baseline = [self._failure("1_a", "oom", "base123")]
+        new = [self._row(test_id="1_a", command="HSET", rps=250000.0, commit="new123")]
+
+        failed, _, report = _comparison(baseline, new)
+        assert len(failed) == 1
+        entry = failed[0]
+        assert entry["side"] == "baseline"
+        assert entry["counterpart_value"] == pytest.approx(250000.0)
+
+        assert "250K rps" in report
+        assert "**FAILED**" in report
+
+    def test_both_sides_failed_rendering(self):
+        baseline = [self._failure("1_a", "baseline oom", "base123")]
+        new = [self._failure("1_a", "new segfault", "new123")]
+
+        _, groups, report = _comparison(baseline, new)
+
+        assert report.count("**FAILED**") == 2
+        assert "baseline: baseline oom" in report
+        assert "new: new segfault" in report
+        assert "-100.0%" not in report
+        assert all(not g["table_rows"] for g in groups)
+
+    def test_failed_scenario_no_counterpart_renders_absent_marker(self):
+        baseline = [self._row(test_id="1_b", command="FT.SEARCH")]
+        new = [
+            self._failure("1_a", "boom", "new123"),
+            self._row(test_id="1_b", command="FT.SEARCH", commit="new123"),
+        ]
+
+        failed, groups, report = _comparison(baseline, new)
+        a_entry = next(e for e in failed if e["test_id"] == "1_a")
+        assert a_entry["counterpart_present"] is False
+        assert a_entry["counterpart_value"] is None
+
+        assert "n/a" in report
+        assert "**FAILED**" in report
+        assert "-100.0%" not in report
+        rps_rows = _metric_rows(groups)
+        assert len(rps_rows) == 1
+        assert rps_rows[0]["change"] == pytest.approx(0.0)
+
+    def test_no_negative_100_percent_for_any_failed_direction(self):
+        directions = [
+            (  # failed in new
+                [self._row(test_id="1_a", command="HSET")],
+                [self._failure("1_a", "boom", "new123")],
+            ),
+            (  # failed in baseline
+                [self._failure("1_a", "oom", "base123")],
+                [self._row(test_id="1_a", command="HSET", commit="new123")],
+            ),
+            (  # failed on both
+                [self._failure("1_a", "oom", "base123")],
+                [self._failure("1_a", "boom", "new123")],
+            ),
+        ]
+        for baseline, new in directions:
+            _, _, report = _comparison(baseline, new)
+            assert "-100.0%" not in report
+            assert "+100.0%" not in report
+
+    @pytest.mark.parametrize(
+        "variant_a, variant_b, label_a, label_b, err_a, err_b",
+        [
+            (  # config_set is part of the identity
+                {"config_set": {"appendonly": "yes"}},
+                {"config_set": {"appendonly": "no"}},
+                "appendonly=yes",
+                "appendonly=no",
+                "err on yes",
+                "err on no",
+            ),
+            (  # cluster_mode is part of the identity too
+                {"cluster_mode": False},
+                {"cluster_mode": True},
+                "cluster=False",
+                "cluster=True",
+                "boom single",
+                "boom cluster",
+            ),
+        ],
+    )
+    def test_same_test_id_two_variants_render_two_rows(
+        self, variant_a, variant_b, label_a, label_b, err_a, err_b
+    ):
+        baseline = [
+            self._row(test_id="1_a", command="HSET", rps=100000.0, **variant_a),
+            self._row(test_id="1_a", command="HSET", rps=500000.0, **variant_b),
+        ]
+        new = [
+            self._failure("1_a", err_a, "new123", **variant_a),
+            self._failure("1_a", err_b, "new123", **variant_b),
+        ]
+
+        _, _, report = _comparison(baseline, new)
+
+        assert "## ⚠️ 2 failed scenario(s)" in report
+        assert label_a in report
+        assert label_b in report
+        assert err_a in report
+        assert err_b in report
+        assert "100K rps" in report
+        assert "500K rps" in report
+        assert "300K rps" not in report
+        row_lines = [
+            ln for ln in report.splitlines() if ln.startswith("| ") and "1_a" in ln
+        ]
+        assert len(row_lines) == 2
+
+    def test_single_config_set_still_renders_one_row(self):
+        baseline = [self._row(test_id="1_a", command="HSET", rps=100000.0)]
+        new = [self._failure("1_a", "boom", "new123")]
+
+        _, _, report = _comparison(baseline, new)
+
+        assert "## ⚠️ 1 failed scenario(s)" in report
+        row_lines = [
+            ln for ln in report.splitlines() if ln.startswith("| ") and "1_a" in ln
+        ]
+        assert len(row_lines) == 1
+        assert row_lines[0].startswith("| ` 1_a ` |")
+        assert "appendonly=" not in report
+        assert "cluster=" not in report
+
+
+class TestScenarioIdentityAndCellSanitization:
+    def _row(self, **overrides):
+        overrides.setdefault("test_id", "1_a")
+        return real_success_row(**overrides)
+
+    def _failure(self, test_id, error, side_commit, command="HSET", **overrides):
+        return real_failure_row(
+            test_id, error, command=command, commit=side_commit, **overrides
+        )
+
+    @pytest.mark.parametrize(
+        "variant_a, variant_b, base_rps, new_rps",
+        [
+            (
+                {"config_set": {"maxmemory": "100mb"}},
+                {"config_set": {"maxmemory": "200mb"}},
+                200000.0,
+                220000.0,
+            ),
+            ({"cluster_mode": False}, {"cluster_mode": True}, 300000.0, 330000.0),
+        ],
+    )
+    def test_healthy_sibling_survives_when_one_variant_fails(
+        self, variant_a, variant_b, base_rps, new_rps
+    ):
+        baseline = [
+            self._row(test_id="1_a", rps=100000.0, **variant_a),
+            self._row(test_id="1_a", rps=base_rps, **variant_b),
+        ]
+        new = [
+            self._failure("1_a", "boom", "new123", **variant_a),
+            self._row(test_id="1_a", rps=new_rps, commit="new123", **variant_b),
+        ]
+
+        failed, groups, report = _comparison(baseline, new)
+        rps_rows = _metric_rows(groups)
+
+        assert len(rps_rows) == 1
+        assert rps_rows[0]["baseline_value"] == pytest.approx(base_rps)
+        assert rps_rows[0]["new_value"] == pytest.approx(new_rps)
+        assert rps_rows[0]["change"] == pytest.approx(10.0)
+
+    def test_counterpart_value_reflects_only_matching_config_set(self):
+        cfg_a = {"maxmemory": "100mb"}
+        cfg_b = {"maxmemory": "200mb"}
+        baseline = [
+            self._row(test_id="1_a", config_set=cfg_a, rps=100000.0),
+            self._row(test_id="1_a", config_set=cfg_b, rps=900000.0),
+        ]
+        new = [
+            self._failure("1_a", "boom", "new123", config_set=cfg_a),
+            self._row(test_id="1_a", config_set=cfg_b, rps=950000.0, commit="new123"),
+        ]
+
+        failed = collect_failed_scenarios(baseline, new)
+        assert len(failed) == 1
+        entry = failed[0]
+        assert entry["side"] == "new"
+        assert entry["counterpart_value"] == pytest.approx(100000.0)
+
+    def test_legacy_row_without_test_id_never_excluded_and_still_renders(self):
+        legacy_ok = {
+            "command": "GET",
+            "pipeline": 1,
+            "io_threads": 4,
+            "data_size": 16,
+            "clients": 50,
+            "rps": 100000.0,
+            "avg_latency_ms": 0.5,
+        }
+        failed_legacy = {
+            "status": "failed",
+            "error": "legacy runner died",
+            "command": "SET",
+            "timestamp": "<TS>",
+        }
+        baseline = [
+            {**legacy_ok, "commit": "base123"},
+            self._row(test_id="1_a", command="HSET"),
+        ]
+        new = [
+            {**legacy_ok, "rps": 110000.0, "commit": "new123"},
+            self._failure("1_a", "scenario boom", "new123"),
+            failed_legacy,
+        ]
+
+        _, groups, report = _comparison(baseline, new)
+
+        rps_rows = _metric_rows(groups)
+        assert len(rps_rows) == 1
+        assert rps_rows[0]["baseline_value"] == pytest.approx(100000.0)
+        assert rps_rows[0]["new_value"] == pytest.approx(110000.0)
+        assert rps_rows[0]["change"] == pytest.approx(10.0)
+
+        assert "legacy runner died" in report
+        assert "1_a" in report
+
+    def test_injection_in_command_and_error_is_inert(self):
+        injected_command = (
+            r"[click](http://evil.example) @octocat #83 GH-83 "
+            r"a@example.com <img src=x> a|b"
+        )
+        injected_error = r"boom `rm -rf` ``two ticks`` *bold* _em_" + "\r done"
+        baseline = [self._row(test_id="1_a", command="HSET")]
+        new = [self._failure("1_a", injected_error, "new123", command=injected_command)]
+
+        _, _, report = _comparison(baseline, new)
+
+        assert (
+            "` [click](http://evil.example) @octocat #83 GH-83 "
+            "a@example.com <img src=x> a\\|b `"
+        ) in report
+        assert "``` boom `rm -rf` ``two ticks`` *bold* _em_  done ```" in report
+        assert "\r" not in report
+        assert report.count("| --- | --- | --- | --- | --- | --- |") == 1
+        data_row = next(
+            line
+            for line in report.splitlines()
+            if line.startswith("| ") and "1_a" in line
+        )
+        assert data_row.count(" | ") == 5
+        assert data_row.count(r"\|") == 1
+
+    def test_version_header_is_sanitized(self):
+        baseline = [self._row(test_id="1_a", command="HSET")]
+        new = [self._failure("1_a", "boom", "new123")]
+        failed = collect_failed_scenarios(baseline, new)
+        groups, _b, _n, brepo, nrepo = create_comparison_table_data(baseline, new)
+
+        report = format_comparison_report(
+            groups,
+            "[evil](http://evil.example)",
+            "v1|v2",
+            brepo,
+            nrepo,
+            failed_scenarios=failed,
+        )
+
+        assert "` [evil](http://evil.example) `" in report
+        assert r"` v1\|v2 `" in report
+
+
+class TestRealProducerFailurePairing:
+    def test_real_failure_marker_pairs_with_real_success_row(self):
+        baseline = [
+            real_success_row(
+                test_id="1_a",
+                command="HSET",
+                cluster_mode=False,
+                io_threads=4,
+                rps=100000.0,
+            )
+        ]
+        new = [
+            real_failure_row(
+                "1_a", "No results", command="HSET", cluster_mode=False, io_threads=4
+            )
+        ]
+
+        assert _scenario_identity(baseline[0]) == _scenario_identity(new[0])
+
+        _, groups, report = _comparison(baseline, new)
+
+        assert _metric_rows(groups) == []
+        assert "**FAILED**" in report
+        assert "-100.0%" not in report
+
+    def test_producer_failure_marker_carries_cluster_mode_and_io_threads(self):
+        marker = real_failure_row(
+            "1_a", "boom", command="HSET", cluster_mode=True, io_threads=8
+        )
+        assert marker["cluster_mode"] is True
+        assert marker["io_threads"] == 8
+        assert marker["status"] == "failed"
+        assert "rps" not in marker
+
+    def test_io_threads_sweep_sibling_survives_when_one_thread_count_fails(self):
+        baseline = [
+            real_success_row(test_id="1_a", command="HSET", io_threads=4, rps=100000.0),
+            real_success_row(test_id="1_a", command="HSET", io_threads=8, rps=300000.0),
+        ]
+        new = [
+            real_success_row(
+                test_id="1_a", command="HSET", io_threads=4, rps=110000.0, commit="new"
+            ),
+            real_failure_row("1_a", "boom", command="HSET", io_threads=8, commit="new"),
+        ]
+
+        failed, groups, report = _comparison(baseline, new)
+        rps_rows = _metric_rows(groups)
+
+        assert len(rps_rows) == 1
+        assert rps_rows[0]["baseline_value"] == pytest.approx(100000.0)
+        assert rps_rows[0]["new_value"] == pytest.approx(110000.0)
+        assert rps_rows[0]["change"] == pytest.approx(10.0)
+
+
+class TestAveragingStageConfigSet:
+    @staticmethod
+    def _run_pipeline(baseline, new):
+        failed = collect_failed_scenarios(baseline, new)
+        shared = discover_config_keys(baseline + new)
+        baseline_avg = average_multiple_runs(baseline, shared)
+        new_avg = average_multiple_runs(new, shared)
+        groups, bver, nver, brepo, nrepo = create_comparison_table_data(
+            baseline_avg, new_avg
+        )
+        return failed, baseline_avg, new_avg, groups, bver, nver, brepo, nrepo
+
+    def test_config_set_sweep_not_collapsed_reproduction(self):
+        baseline = [
+            real_success_row(
+                test_id="1_a",
+                command="HSET",
+                config_set={"maxmemory": "1gb"},
+                rps=100.0,
+                commit="base",
+            ),
+            real_success_row(
+                test_id="1_a",
+                command="HSET",
+                config_set={"maxmemory": "4gb"},
+                rps=200.0,
+                commit="base",
+            ),
+        ]
+        new = [
+            real_failure_row(
+                "1_a",
+                "oom",
+                command="HSET",
+                config_set={"maxmemory": "1gb"},
+                commit="new",
+            ),
+            real_success_row(
+                test_id="1_a",
+                command="HSET",
+                config_set={"maxmemory": "4gb"},
+                rps=220.0,
+                commit="new",
+            ),
+        ]
+
+        failed, baseline_avg, new_avg, groups, bver, nver, brepo, nrepo = (
+            self._run_pipeline(baseline, new)
+        )
+
+        assert len(baseline_avg) == 2
+        assert {r["run_count"] for r in baseline_avg} == {1}
+        assert sorted(r["rps"] for r in baseline_avg) == [100.0, 200.0]
+
+        rps_rows = _metric_rows(groups)
+        assert len(rps_rows) == 1
+        assert rps_rows[0]["baseline_value"] == pytest.approx(200.0)
+        assert rps_rows[0]["new_value"] == pytest.approx(220.0)
+        assert rps_rows[0]["change"] == pytest.approx(10.0)
+        assert rps_rows[0]["change"] != pytest.approx(46.7, abs=1.0)
+
+        report = format_comparison_report(
+            groups, bver, nver, brepo, nrepo, failed_scenarios=failed
+        )
+        assert "1gb" in report
+        assert "oom" in report
+        assert "-100.0%" not in report
+        assert "+46.7%" not in report
+
+    def test_genuine_repeated_runs_same_config_set_still_average(self):
+        baseline = [
+            real_success_row(
+                test_id="1_a",
+                command="HSET",
+                config_set={"maxmemory": "1gb"},
+                rps=100.0,
+            ),
+            real_success_row(
+                test_id="1_a",
+                command="HSET",
+                config_set={"maxmemory": "1gb"},
+                rps=200.0,
+            ),
+            real_success_row(
+                test_id="1_a",
+                command="HSET",
+                config_set={"maxmemory": "1gb"},
+                rps=300.0,
+            ),
+        ]
+        shared = discover_config_keys(baseline)
+        averaged = average_multiple_runs(baseline, shared)
+
+        assert len(averaged) == 1
+        assert averaged[0]["run_count"] == 3
+        assert averaged[0]["rps"] == pytest.approx(200.0)
+        assert averaged[0]["rps_stdev"] > 0.0
+        assert averaged[0]["config_set"] == {"maxmemory": "1gb"}
+
+    def test_no_config_set_runs_average_as_before(self):
+        baseline = [
+            real_success_row(command="GET", rps=100.0),
+            real_success_row(command="GET", rps=200.0),
+        ]
+        for row in baseline:
+            assert "config_set" not in row
+
+        shared = discover_config_keys(baseline)
+        averaged = average_multiple_runs(baseline, shared)
+
+        assert len(averaged) == 1
+        assert averaged[0]["run_count"] == 2
+        assert averaged[0]["rps"] == pytest.approx(150.0)
+        assert "config_set" not in averaged[0]
+
+    def test_two_config_sets_each_repeated_average_within_config_set(self):
+        def runs(config_set, rps_pair):
+            return [
+                real_success_row(
+                    test_id="1_a", command="HSET", config_set=config_set, rps=rps
+                )
+                for rps in rps_pair
+            ]
+
+        baseline = runs({"maxmemory": "1gb"}, [100.0, 120.0]) + runs(
+            {"maxmemory": "4gb"}, [200.0, 240.0]
+        )
+        shared = discover_config_keys(baseline)
+        averaged = average_multiple_runs(baseline, shared)
+
+        assert len(averaged) == 2
+        assert {r["run_count"] for r in averaged} == {2}
+        by_cfg = {r["config_set"]["maxmemory"]: r["rps"] for r in averaged}
+        assert by_cfg == {"1gb": pytest.approx(110.0), "4gb": pytest.approx(220.0)}
+
+
+class TestStructuralIdentityAndAttribution:
+    def test_tls_variants_pair_independently_and_failure_not_smeared(self):
+        baseline = [
+            real_success_row(test_id="1_a", tls_mode=False, rps=100.0),
+            real_success_row(test_id="1_a", tls_mode=True, rps=500.0),
+        ]
+        new = [
+            real_success_row(test_id="1_a", tls_mode=False, rps=110.0, commit="new123"),
+            real_failure_row("1_a", "tls boom", tls_mode=True, commit="new123"),
+        ]
+
+        failed, groups, report = _comparison(baseline, new)
+        rps_rows = _metric_rows(groups)
+        assert len(rps_rows) == 1
+        assert rps_rows[0]["baseline_value"] == pytest.approx(100.0)
+        assert rps_rows[0]["new_value"] == pytest.approx(110.0)
+        assert rps_rows[0]["change"] == pytest.approx(10.0)
+
+        assert len(failed) == 1
+        assert failed[0]["counterpart_value"] == pytest.approx(500.0)
+        assert "1_a (tls=True)" in report
+
+    def test_command_difference_does_not_break_pairing(self):
+        baseline = [
+            real_success_row(test_id="1_a", command="MSET (10 keys)", rps=100.0)
+        ]
+        new = [real_failure_row("1_a", "boom", command="MSET", commit="new123")]
+
+        failed = collect_failed_scenarios(baseline, new)
+        assert len(failed) == 1
+        assert failed[0]["counterpart_value"] == pytest.approx(100.0)
+
+    def test_all_failed_module_dataset_labeled_with_module_commit(self):
+        markers = [
+            real_failure_row(
+                "1_a",
+                "boom",
+                commit="core_sha",
+                module_commit="module_sha_1234567890",
+                module_commit_timestamp="2026-01-01T00:00:00Z",
+                config_name="fts.json",
+            )
+        ]
+        assert markers[0]["module_commit"] == "module_sha_1234567890"
+        assert extract_version_identifier(markers) == "module_s"
+        core_only = [real_failure_row("1_a", "boom", commit="corecommit123")]
+        assert extract_version_identifier(core_only) == "corecomm"
+
+    def test_mixed_failure_no_fabricated_regression_end_to_end(self):
+        baseline = [
+            real_success_row(
+                test_id="1_mix_write_w", test_phase="mixed_write", rps=100.0
+            ),
+            real_success_row(
+                test_id="1_mix_read_r1", test_phase="mixed_read", rps=200.0
+            ),
+        ]
+        new = [
+            real_failure_row(
+                "1_mix_write_w", "write boom", phase="mixed_write", commit="new123"
+            ),
+            real_success_row(
+                test_id="1_mix_read_r1",
+                test_phase="mixed_read",
+                rps=210.0,
+                commit="new123",
+            ),
+        ]
+
+        groups, *_ = create_comparison_table_data(baseline, new)
+        rps_rows = _metric_rows(groups)
+        assert len(rps_rows) == 1
+        assert rps_rows[0]["baseline_value"] == pytest.approx(200.0)
+        assert rps_rows[0]["new_value"] == pytest.approx(210.0)
+        assert rps_rows[0]["change"] == pytest.approx(5.0)
+        assert all(r["change"] != pytest.approx(-100.0) for r in rps_rows)
+
+        failed = collect_failed_scenarios(baseline, new)
+        assert len(failed) == 1
+        assert failed[0]["test_id"] == "1_mix_write_w"
+        assert failed[0]["counterpart_value"] == pytest.approx(100.0)
+
+
+class TestVolatileVsStableEnvClassification:
+    """Stable environment identity versus volatile live readings."""
+
+    def test_stable_env_field_prevents_comparison(self):
+        baseline = [
+            real_success_row(test_id="1_a", rps=100000.0, env_cpu_model="AMD EPYC")
+        ]
+        new = [
+            real_success_row(
+                test_id="1_a",
+                rps=200000.0,
+                commit="new123",
+                env_cpu_model="Intel Xeon",
+            )
+        ]
+
+        groups, *_ = create_comparison_table_data(baseline, new)
+        rps_rows = _metric_rows(groups)
+
+        assert len(groups) == 2
+        assert not any(r["baseline_value"] > 0 and r["new_value"] > 0 for r in rps_rows)
+
+    def test_volatile_freq_field_still_compares(self):
+        baseline = [
+            real_success_row(
+                test_id="1_a", rps=100000.0, env_cpu_freq_mhz_at_setup=3200
+            )
+        ]
+        new = [
+            real_success_row(
+                test_id="1_a",
+                rps=110000.0,
+                commit="new123",
+                env_cpu_freq_mhz_at_setup=3105,
+            )
+        ]
+
+        groups, *_ = create_comparison_table_data(baseline, new)
+        rps_rows = _metric_rows(groups)
+
+        assert len(groups) == 1
+        assert len(rps_rows) == 1
+        assert rps_rows[0]["baseline_value"] == pytest.approx(100000.0)
+        assert rps_rows[0]["new_value"] == pytest.approx(110000.0)
+        assert rps_rows[0]["change"] == pytest.approx(10.0)
+
+    def test_stable_env_field_is_identity_axis_and_pairs_same_host(self):
+        baseline = [
+            real_success_row(test_id="1_a", rps=100.0, env_cpu_model="AMD EPYC")
+        ]
+        new = [
+            real_failure_row("1_a", "boom", commit="new123", env_cpu_model="AMD EPYC")
+        ]
+
+        assert ("env_cpu_model", "AMD EPYC") in _scenario_identity(baseline[0])
+        failed = collect_failed_scenarios(baseline, new)
+        assert len(failed) == 1
+        assert failed[0]["counterpart_value"] == pytest.approx(100.0)
+
+
+class TestConfigSetGroupHeadingAttribution:
+    def test_two_config_sets_render_attributable_headings(self):
+        cfg_1gb = {"maxmemory": "1gb"}
+        cfg_4gb = {"maxmemory": "4gb"}
+        baseline = [
+            real_success_row(test_id="1_a", config_set=cfg_1gb, rps=100.0),
+            real_success_row(test_id="1_a", config_set=cfg_4gb, rps=500.0),
+        ]
+        new = [
+            real_success_row(
+                test_id="1_a", config_set=cfg_1gb, rps=110.0, commit="new123"
+            ),
+            real_success_row(
+                test_id="1_a", config_set=cfg_4gb, rps=550.0, commit="new123"
+            ),
+        ]
+
+        _, _, report = _comparison(baseline, new)
+
+        headings = [line for line in report.splitlines() if line.startswith("###")]
+        assert "### config_set = ` maxmemory=1gb `" in headings
+        assert "### config_set = ` maxmemory=4gb `" in headings
+        base_no_cs = [
+            real_success_row(test_id="1_a", data_size=16, rps=100.0),
+            real_success_row(test_id="1_a", data_size=64, rps=200.0),
+        ]
+        new_no_cs = [
+            real_success_row(test_id="1_a", data_size=16, rps=110.0, commit="new123"),
+            real_success_row(test_id="1_a", data_size=64, rps=220.0, commit="new123"),
+        ]
+        _, _, report2 = _comparison(base_no_cs, new_no_cs)
+
+        assert "config_set" not in report2
+        headings2 = [line for line in report2.splitlines() if line.startswith("###")]
+        assert "### data_size = 16" in headings2
+        assert "### data_size = 64" in headings2

--- a/tests/test_modify_config.py
+++ b/tests/test_modify_config.py
@@ -1,0 +1,1298 @@
+"""Unit tests for utils/modify_config.py.
+
+Cover predefined-command overrides, arbitrary-command scenario generation,
+populate ordering, the derived server_cpu_range ceiling, every validation
+rejection, and that generated configs pass the framework's validate_config.
+"""
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmark import validate_config
+from utils.modify_config import (
+    ConfigModificationError,
+    build_config,
+    main,
+)
+
+
+@pytest.fixture
+def base_config():
+    """Single-entry base config in the shape workflows start from."""
+    return [
+        {
+            "duration": 180,
+            "keyspacelen": [3000000],
+            "data_sizes": [16, 128, 2048],
+            "pipelines": [1, 10],
+            "clients": [1600],
+            "commands": ["SET", "GET"],
+            "cluster_mode": False,
+            "tls_mode": False,
+            "warmup": 30,
+            "io-threads": [1, 9],
+            "benchmark-threads": 90,
+            "server_cpu_range": "0-8",
+            "client_cpu_range": "96-191",
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Predefined-command mode
+# ---------------------------------------------------------------------------
+
+
+class TestPredefinedOverrides:
+    """WHEN predefined parameters are supplied, they SHALL land on entry [0]."""
+
+    def test_overrides_land_on_entry(self, base_config):
+        result = build_config(
+            base_config,
+            commands="set,get,hset",
+            data_size="32,64",
+            pipelines="1,20",
+            io_threads="1,4",
+            benchmark_threads="48",
+            cluster_mode=True,
+        )
+        entry = result[0]
+        assert entry["commands"] == ["SET", "GET", "HSET"]  # upper-cased
+        assert entry["data_sizes"] == [32, 64]
+        assert entry["pipelines"] == [1, 20]
+        assert entry["io-threads"] == [1, 4]
+        assert entry["benchmark-threads"] == 48
+        assert entry["cluster_mode"] is True
+        # Untouched fields are preserved.
+        assert entry["keyspacelen"] == [3000000]
+        assert entry["client_cpu_range"] == "96-191"
+        assert "test_groups" not in entry
+
+    def test_omitted_params_leave_base_untouched(self, base_config):
+        original = copy.deepcopy(base_config)
+        result = build_config(base_config)
+        assert result == original
+
+    def test_input_not_mutated(self, base_config):
+        original = copy.deepcopy(base_config)
+        build_config(base_config, commands="SET", data_size="64")
+        assert base_config == original
+
+
+# ---------------------------------------------------------------------------
+# Derived server_cpu_range (ceiling cap)
+# ---------------------------------------------------------------------------
+
+
+class TestServerCpuRange:
+    """WHEN io-threads are supplied, server_cpu_range SHALL be
+    0-(max_io_threads - 1), capped at the configurable ceiling."""
+
+    def test_derived_from_max_io_thread(self, base_config):
+        result = build_config(base_config, io_threads="1,4,8")
+        assert result[0]["server_cpu_range"] == "0-7"
+
+    def test_capped_at_ceiling(self, base_config):
+        # max io-thread 20 -> 19, already at the default ceiling.
+        result = build_config(base_config, io_threads="1,20")
+        assert result[0]["server_cpu_range"] == "0-19"
+
+    def test_ceiling_is_a_parameter(self, base_config):
+        result = build_config(
+            base_config, io_threads="1,16", server_cpu_ceiling=7, max_io_threads=32
+        )
+        # 16 - 1 = 15, capped at ceiling 7.
+        assert result[0]["server_cpu_range"] == "0-7"
+
+
+# ---------------------------------------------------------------------------
+# Arbitrary-command mode
+# ---------------------------------------------------------------------------
+
+
+class TestArbitraryMode:
+    """WHEN an arbitrary command is supplied, a test_groups block SHALL be
+    generated (one scenario per pipeline x data_size) and the predefined
+    fields removed."""
+
+    def test_generates_pipeline_x_datasize_scenarios(self, base_config):
+        result = build_config(
+            base_config,
+            arbitrary_command="GETRANGE key:__rand_int__ 0 100",
+            data_size="16,64",
+            pipelines="1,10",
+        )
+        entry = result[0]
+        # Predefined fields removed, scenario fields generated.
+        for removed in ("commands", "data_sizes", "pipelines"):
+            assert removed not in entry
+        scenarios = entry["test_groups"][0]["scenarios"]
+        ids = [s["id"] for s in scenarios]
+        assert ids == [
+            "cmd_p1_d16",
+            "cmd_p10_d16",
+            "cmd_p1_d64",
+            "cmd_p10_d64",
+        ]
+        first = scenarios[0]
+        assert first["command"] == "GETRANGE key:__rand_int__ 0 100"
+        assert first["type"] == "arbitrary"
+        assert first["clients"] == 1600  # base clients[0]
+        assert first["pipeline"] == 1
+        assert first["data_size"] == 16
+        assert first["duration"] == 180  # base duration
+        assert first["warmup"] == 30  # base warmup
+
+    def test_preserves_non_predefined_fields(self, base_config):
+        result = build_config(
+            base_config,
+            arbitrary_command="SET key:__rand_int__ __data__",
+            io_threads="1,4",
+            benchmark_threads="50",
+            cluster_mode=True,
+        )
+        entry = result[0]
+        assert entry["keyspacelen"] == [3000000]
+        assert entry["tls_mode"] is False
+        assert entry["client_cpu_range"] == "96-191"
+        # Shared overrides still apply in arbitrary mode.
+        assert entry["io-threads"] == [1, 4]
+        assert entry["server_cpu_range"] == "0-3"
+        assert entry["benchmark-threads"] == 50
+        assert entry["cluster_mode"] is True
+
+    def test_falls_back_to_base_sweep(self, base_config):
+        # No --data-size / --pipelines: sweep comes from the base config.
+        result = build_config(base_config, arbitrary_command="GET key:__rand_int__")
+        ids = [s["id"] for s in result[0]["test_groups"][0]["scenarios"]]
+        # base data_sizes [16,128,2048] x pipelines [1,10]
+        assert ids == [
+            "cmd_p1_d16",
+            "cmd_p10_d16",
+            "cmd_p1_d128",
+            "cmd_p10_d128",
+            "cmd_p1_d2048",
+            "cmd_p10_d2048",
+        ]
+
+    def test_commands_with_arbitrary_command_rejected(self, base_config):
+        with pytest.raises(ConfigModificationError, match="cannot be combined"):
+            build_config(
+                base_config,
+                commands="SET,GET",
+                arbitrary_command="GET key:__rand_int__",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Populate mode
+# ---------------------------------------------------------------------------
+
+
+class TestPopulateMode:
+    """WHEN a populate command is supplied, each read scenario SHALL carry it
+    as ``populate_with`` so the framework shares one seed between the populate
+    pass and the main run; NO separate populate scenario is emitted."""
+
+    def test_populate_with_on_each_read_no_separate_scenario(self, base_config):
+        result = build_config(
+            base_config,
+            arbitrary_command="GET key:__rand_int__",
+            populate_command="SET key:__rand_int__ __data__",
+            data_size="16,64",
+            pipelines="1,10",
+        )
+        scenarios = result[0]["test_groups"][0]["scenarios"]
+        ids = [s["id"] for s in scenarios]
+        # One scenario per pipeline x data_size; NO populate_d* scenarios.
+        assert ids == [
+            "cmd_p1_d16",
+            "cmd_p10_d16",
+            "cmd_p1_d64",
+            "cmd_p10_d64",
+        ]
+        assert all(
+            s.get("populate_with") == "SET key:__rand_int__ __data__" for s in scenarios
+        )
+        assert all(s["type"] == "arbitrary" for s in scenarios)
+
+    def test_no_populate_with_when_populate_absent(self, base_config):
+        result = build_config(
+            base_config,
+            arbitrary_command="GET key:__rand_int__",
+            data_size="16",
+            pipelines="1",
+        )
+        scenarios = result[0]["test_groups"][0]["scenarios"]
+        assert all("populate_with" not in s for s in scenarios)
+
+    def test_finding1_populate_and_main_share_seed(self, base_config):
+        """End-to-end: the populate pass and the main run get the SAME --seed.
+
+        Builds both argv through ClientRunner with ``random.randint`` patched;
+        both invocations must carry the one drawn seed.
+        """
+        from unittest.mock import patch
+
+        from valkey_benchmark import ClientRunner
+
+        result = build_config(
+            base_config,
+            arbitrary_command="GET key:__rand_int__",
+            populate_command="SET key:__rand_int__ __data__",
+            data_size="16",
+            pipelines="1",
+        )
+        entry = result[0]
+        scenario = entry["test_groups"][0]["scenarios"][0]
+
+        runner = ClientRunner(
+            commit_id="abc123",
+            config=entry,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp/test_results"),
+            valkey_path="/tmp/valkey",
+            valkey_benchmark_path="src/valkey-benchmark",
+        )
+
+        captured = []
+
+        def _capture(*args, **kwargs):
+            captured.append(list(kwargs.get("command", args[0] if args else [])))
+            return None
+
+        with patch("valkey_benchmark.random.randint", return_value=424242):
+            seed_val = runner._draw_scenario_seed(scenario, origin_simple=False)
+            with patch.object(runner, "_run", side_effect=_capture):
+                runner._populate_scenario_keyspace(scenario, seed_val)
+                runner._execute_benchmark_run(scenario, seed_val)
+
+        assert len(captured) == 2, "expected a populate argv and a main argv"
+
+        def _seed_of(argv):
+            return argv[argv.index("--seed") + 1]
+
+        populate_seed = _seed_of(captured[0])
+        main_seed = _seed_of(captured[1])
+        assert populate_seed == main_seed == "424242"
+
+
+# ---------------------------------------------------------------------------
+# Validation rejections
+# ---------------------------------------------------------------------------
+
+
+class TestValidationRejections:
+    """WHEN an input is out of range or malformed, build_config SHALL raise
+    ConfigModificationError."""
+
+    @pytest.mark.parametrize(
+        "kwargs, match",
+        [
+            ({"data_size": "0"}, "data_size"),
+            ({"data_size": "1048577"}, "data_size"),
+            ({"io_threads": "21"}, "io_threads"),
+            ({"pipelines": "1001"}, "pipelines"),
+            ({"benchmark_threads": "97"}, "benchmark_threads"),
+            ({"data_size": "16,abc"}, "data_size"),
+            ({"arbitrary_command": "GET a\nSET b c"}, "single line"),
+            ({"arbitrary_command": "GET " + "x" * 512}, "at most 512"),
+            (
+                {
+                    "arbitrary_command": "GET key:__rand_int__",
+                    "populate_command": "SET a b\nSET c d",
+                },
+                "single line",
+            ),
+            (
+                {"populate_command": "SET key:__rand_int__ __data__"},
+                "requires arbitrary_command",
+            ),
+            ({"commands": "SET,FLUSHALL"}, "Unsupported command"),
+        ],
+    )
+    def test_invalid_input_rejected(self, base_config, kwargs, match):
+        with pytest.raises(ConfigModificationError, match=match):
+            build_config(base_config, **kwargs)
+
+    def test_empty_config(self):
+        with pytest.raises(ConfigModificationError, match="non-empty JSON array"):
+            build_config([])
+
+
+# ---------------------------------------------------------------------------
+# Framework validation of generated output
+# ---------------------------------------------------------------------------
+
+
+class TestGeneratedConfigPassesValidation:
+    """The generated config SHALL pass the framework's validate_config."""
+
+    def test_predefined_passes(self, base_config):
+        result = build_config(
+            base_config, commands="SET,GET", data_size="64", pipelines="10"
+        )
+        validate_config(copy.deepcopy(result[0]))  # should not raise
+
+    def test_arbitrary_passes(self, base_config):
+        result = build_config(
+            base_config,
+            arbitrary_command="GETRANGE key:__rand_int__ 0 100",
+            data_size="16,64",
+            pipelines="1,10",
+        )
+        validate_config(copy.deepcopy(result[0]))  # should not raise
+
+    def test_arbitrary_with_populate_passes(self, base_config):
+        result = build_config(
+            base_config,
+            arbitrary_command="GET key:__rand_int__",
+            populate_command="SET key:__rand_int__ __data__",
+        )
+        validate_config(copy.deepcopy(result[0]))  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# CLI / file IO
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    """WHEN invoked as a CLI, main SHALL read, modify, and write the config."""
+
+    def _write(self, tmp_path, config):
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(config))
+        return path
+
+    def test_output_defaults_to_overwrite(self, tmp_path, base_config):
+        path = self._write(tmp_path, base_config)
+        rc = main(["--config", str(path), "--commands", "hset"])
+        assert rc == 0
+        written = json.loads(path.read_text())
+        assert written[0]["commands"] == ["HSET"]
+
+    def test_writes_to_separate_output(self, tmp_path, base_config):
+        path = self._write(tmp_path, base_config)
+        out = tmp_path / "out.json"
+        rc = main(
+            [
+                "--config",
+                str(path),
+                "--output",
+                str(out),
+                "--arbitrary-command",
+                "GET key:__rand_int__",
+            ]
+        )
+        assert rc == 0
+        # Input untouched, output holds the generated test_groups.
+        assert json.loads(path.read_text())[0]["commands"] == ["SET", "GET"]
+        assert "test_groups" in json.loads(out.read_text())[0]
+
+    def test_invalid_input_returns_nonzero(self, tmp_path, base_config):
+        path = self._write(tmp_path, base_config)
+        rc = main(["--config", str(path), "--data-size", "0"])
+
+
+# ---------------------------------------------------------------------------
+# Request-bound / scenario-format bases
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def request_based_config():
+    """Base whose entry is request-bound (no duration)."""
+    return [
+        {
+            "requests": [1000000],
+            "keyspacelen": [3000000],
+            "data_sizes": [16],
+            "pipelines": [1],
+            "clients": [1600],
+            "commands": ["SET", "GET"],
+            "cluster_mode": False,
+            "tls_mode": False,
+            "warmup": 0,
+        }
+    ]
+
+
+@pytest.fixture
+def scenario_format_config():
+    """Base entry [0] already in scenario (test_groups) format."""
+    return [
+        {
+            "cluster_mode": False,
+            "tls_mode": False,
+            "test_groups": [
+                {
+                    "group": 1,
+                    "scenarios": [
+                        {"id": "s1", "command": "SET foo bar", "type": "write"}
+                    ],
+                }
+            ],
+        }
+    ]
+
+
+class TestFinding2RunBound:
+    """A request-based base SHALL carry 'requests' onto scenarios, not silently
+    become a 60-second duration run; a base with neither is rejected."""
+
+    def test_requests_carried_not_dropped(self, request_based_config):
+        result = build_config(
+            request_based_config,
+            arbitrary_command="GET key:__rand_int__",
+            data_size="16",
+            pipelines="1",
+        )
+        scenario = result[0]["test_groups"][0]["scenarios"][0]
+        assert scenario.get("requests") == 1000000
+        assert "duration" not in scenario  # never both, never a silent fallback
+
+    def test_duration_carried_when_present(self, base_config):
+        result = build_config(
+            base_config,
+            arbitrary_command="GET key:__rand_int__",
+            data_size="16",
+            pipelines="1",
+        )
+        scenario = result[0]["test_groups"][0]["scenarios"][0]
+        assert scenario.get("duration") == 180
+        assert "requests" not in scenario
+
+    def test_neither_duration_nor_requests_rejected(self, base_config):
+        broken = copy.deepcopy(base_config)
+        del broken[0]["duration"]
+        broken[0].pop("requests", None)
+        with pytest.raises(ConfigModificationError, match="duration.*or.*requests"):
+            build_config(broken, arbitrary_command="GET key:__rand_int__")
+
+
+class TestFinding3CommandParsing:
+    """Malformed arbitrary/populate commands SHALL be rejected at script time via
+    shlex parsing, not after the benchmark starts."""
+
+    @pytest.mark.parametrize(
+        "kwargs, match",
+        [
+            ({"arbitrary_command": "GET 'unterminated"}, "arbitrary_command"),
+            ({"arbitrary_command": "GET key\\"}, "arbitrary_command"),
+            ({"arbitrary_command": "   "}, "at least one token"),
+            (
+                {
+                    "arbitrary_command": "GET key:__rand_int__",
+                    "populate_command": "SET 'unterminated",
+                },
+                "populate_command",
+            ),
+        ],
+    )
+    def test_malformed_command_rejected(self, base_config, kwargs, match):
+        with pytest.raises(ConfigModificationError, match=match):
+            build_config(base_config, **kwargs)
+
+
+class TestFinding4ScenarioFormatBase:
+    """Predefined-only overrides SHALL be rejected against a base that is already
+    in scenario format; universal entry-level flags apply."""
+
+    def test_predefined_override_rejected(self, scenario_format_config):
+        with pytest.raises(ConfigModificationError, match="scenario"):
+            build_config(scenario_format_config, commands="SET,GET")
+
+    def test_arbitrary_rejected_against_scenario_base(self, scenario_format_config):
+        with pytest.raises(ConfigModificationError, match="scenario"):
+            build_config(
+                scenario_format_config, arbitrary_command="GET key:__rand_int__"
+            )
+
+    def test_universal_flags_apply_to_scenario_base(self, scenario_format_config):
+        result = build_config(
+            scenario_format_config,
+            io_threads="1,4",
+            benchmark_threads="50",
+            cluster_mode=True,
+        )
+        entry = result[0]
+        assert entry["io-threads"] == [1, 4]
+        assert entry["benchmark-threads"] == 50
+        assert entry["cluster_mode"] is True
+        # The base scenarios are left intact.
+        assert entry["test_groups"][0]["scenarios"][0]["id"] == "s1"
+
+
+class TestFinding5CpuConflicts:
+    """CPU conflicts detectable from the config alone SHALL be rejected at
+    script time."""
+
+    def test_io_threads_range_conflicts_with_cpu_allocation(self, base_config):
+        # Base uses cpu_allocation; deriving server_cpu_range from --io-threads
+        # creates the mutually-exclusive conflict.
+        cfg = copy.deepcopy(base_config)
+        del cfg[0]["server_cpu_range"]
+        del cfg[0]["client_cpu_range"]
+        cfg[0]["cpu_allocation"] = {"cores_per_server": 8, "cores_per_client": 8}
+        with pytest.raises(ConfigModificationError, match="cpu_allocation"):
+            build_config(cfg, commands="SET", io_threads="1,4")
+
+    def test_overlapping_server_client_ranges_rejected(self, base_config):
+        cfg = copy.deepcopy(base_config)
+        cfg[0]["server_cpu_range"] = "0-10"
+        cfg[0]["client_cpu_range"] = "8-20"  # overlaps 8,9,10
+        with pytest.raises(ConfigModificationError, match="overlap"):
+            build_config(cfg, commands="SET")
+
+
+class TestFinding6ClusterTriState:
+    """Cluster mode SHALL be a tri-state — enable, disable, or leave the base
+    alone."""
+
+    def test_disable_against_true_base(self, base_config):
+        cfg = copy.deepcopy(base_config)
+        cfg[0]["cluster_mode"] = True
+        result = build_config(cfg, commands="SET", cluster_mode=False)
+        assert result[0]["cluster_mode"] is False
+
+    def test_enable_against_false_base(self, base_config):
+        result = build_config(base_config, commands="SET", cluster_mode=True)
+        assert result[0]["cluster_mode"] is True
+
+    def test_omitted_leaves_base_alone(self, base_config):
+        cfg = copy.deepcopy(base_config)
+        cfg[0]["cluster_mode"] = True
+        result = build_config(cfg, commands="SET")  # cluster_mode defaults to None
+        assert result[0]["cluster_mode"] is True
+
+
+class TestFinding7Duplicates:
+    """Duplicate list values SHALL be rejected (a duplicate is almost certainly
+    a typo)."""
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"data_size": "16,16"}, {"pipelines": "1,1"}, {"commands": "SET,SET"}],
+    )
+    def test_duplicate_rejected(self, base_config, kwargs):
+        with pytest.raises(ConfigModificationError, match="duplicate"):
+            build_config(base_config, **kwargs)
+
+
+class TestFinding8MalformedLists:
+    """Empty components in comma-separated lists SHALL be rejected rather than
+    silently normalized."""
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{"data_size": "1,,10,"}, {"data_size": ",,,"}, {"commands": "SET,,GET"}],
+    )
+    def test_empty_component_rejected(self, base_config, kwargs):
+        with pytest.raises(ConfigModificationError, match="empty component"):
+            build_config(base_config, **kwargs)
+
+
+class TestFinding9WriteFailure:
+    """An output write failure SHALL be reported as a clean error, not an
+    uncaught traceback."""
+
+    def test_missing_parent_dir_returns_nonzero(self, tmp_path, base_config):
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(base_config))
+        missing = tmp_path / "does_not_exist" / "out.json"
+        rc = main(
+            ["--config", str(path), "--output", str(missing), "--commands", "SET"]
+        )
+        assert rc == 1
+
+
+class TestFinding10BaseShape:
+    """Malformed base configs SHALL surface as ConfigModificationError, not
+    AttributeError/TypeError."""
+
+    def test_entry_not_a_dict(self):
+        with pytest.raises(ConfigModificationError, match="entry \\[0\\]"):
+            build_config(["not a dict"], commands="SET")
+
+    @pytest.mark.parametrize(
+        "field, bad_value", [("data_sizes", 16), ("clients", 1600)]
+    )
+    def test_scalar_list_field_rejected(self, field, bad_value):
+        # A scalar where a list is expected would blow up when read/iterated.
+        broken = [
+            {
+                "duration": 180,
+                "keyspacelen": [3000000],
+                "data_sizes": [16],
+                "pipelines": [1],
+                "clients": [1600],
+                "commands": ["SET"],
+                "cluster_mode": False,
+                "tls_mode": False,
+                "warmup": 0,
+            }
+        ]
+        broken[0][field] = bad_value
+        with pytest.raises(ConfigModificationError, match="must be a list"):
+            build_config(broken, arbitrary_command="GET key:__rand_int__")
+
+
+# ---------------------------------------------------------------------------
+# Mixed mode (simultaneous read + write)
+# ---------------------------------------------------------------------------
+
+
+class TestMixedMode:
+    """WHEN both --write-command and --read-command are supplied, entry [0]
+    SHALL be converted to scenario format with a 'mixed' scenario per
+    pipeline x data_size, its client pool split by --write-ratio."""
+
+    def test_generates_mixed_scenarios_shape_and_ids(self, base_config):
+        result = build_config(
+            base_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET key:__rand_int__",
+            write_ratio=30,
+            data_size="16,64",
+            pipelines="1,10",
+        )
+        entry = result[0]
+        for removed in ("commands", "data_sizes", "pipelines"):
+            assert removed not in entry
+        scenarios = entry["test_groups"][0]["scenarios"]
+        assert [s["id"] for s in scenarios] == [
+            "mix_p1_d16",
+            "mix_p10_d16",
+            "mix_p1_d64",
+            "mix_p10_d64",
+        ]
+        s = scenarios[0]
+        assert s["type"] == "mixed"
+        assert s["pipeline"] == 1
+        assert s["data_size"] == 16
+        assert s["warmup"] == 30  # base warmup
+        assert s["warmup_writes_only"] is True
+        assert s["duration"] == 180  # base duration
+        assert "requests" not in s  # never both
+        assert s["writes"] == [
+            {"id": "w", "command": "SET key:__rand_int__ __data__", "clients": 480}
+        ]
+        assert s["reads"] == [
+            {"id": "r", "command": "GET key:__rand_int__", "clients": 1120}
+        ]
+
+    def test_falls_back_to_base_sweep(self, base_config):
+        result = build_config(
+            base_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET key:__rand_int__",
+        )
+        ids = [s["id"] for s in result[0]["test_groups"][0]["scenarios"]]
+        # base data_sizes [16,128,2048] x pipelines [1,10]
+        assert ids == [
+            "mix_p1_d16",
+            "mix_p10_d16",
+            "mix_p1_d128",
+            "mix_p10_d128",
+            "mix_p1_d2048",
+            "mix_p10_d2048",
+        ]
+
+    def test_default_ratio_is_fifty(self, base_config):
+        result = build_config(
+            base_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET key:__rand_int__",
+            data_size="16",
+            pipelines="1",
+        )
+        s = result[0]["test_groups"][0]["scenarios"][0]
+        assert s["writes"][0]["clients"] == 800
+        assert s["reads"][0]["clients"] == 800
+
+    @pytest.mark.parametrize("ratio, expected_write", [(30, 480), (50, 800), (33, 528)])
+    def test_client_split_sums_exactly_across_ratios(
+        self, base_config, ratio, expected_write
+    ):
+        # CRITICAL: the two sides must sum to the base clients EXACTLY;
+        # flooring both would silently drop connections.
+        result = build_config(
+            base_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET key:__rand_int__",
+            write_ratio=ratio,
+            data_size="16",
+            pipelines="1",
+        )
+        s = result[0]["test_groups"][0]["scenarios"][0]
+        write_clients = s["writes"][0]["clients"]
+        read_clients = s["reads"][0]["clients"]
+        assert write_clients == expected_write
+        assert write_clients + read_clients == 1600  # base clients[0], exact
+
+    @pytest.mark.parametrize(
+        "total, ratio", [(101, 50), (7, 33), (1599, 33), (3, 50), (1600, 33)]
+    )
+    def test_split_helper_sums_on_odd_totals(self, total, ratio):
+        from utils.modify_config import _split_clients
+
+        write_clients, read_clients = _split_clients(total, ratio)
+        assert write_clients + read_clients == total  # exact
+        assert write_clients >= 1 and read_clients >= 1
+        # write side floored; read side deliberately absorbs the remainder.
+        assert write_clients == total * ratio // 100
+        assert read_clients == total - write_clients
+
+    def test_cpu_allocation_emitted_and_ranges_removed(self, base_config):
+        result = build_config(
+            base_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET key:__rand_int__",
+            data_size="16",
+            pipelines="1",
+        )
+        entry = result[0]
+        # Ranges folded into cpu_allocation and removed (mutually exclusive).
+        assert "server_cpu_range" not in entry
+        assert "client_cpu_range" not in entry
+        alloc = entry["cpu_allocation"]
+        # 96-191 is 96 cores / 2 concurrent processes = 48 cores each.
+        assert alloc["cores_per_client"] == 48
+        assert alloc["clients"] == ["96-191"]
+        assert alloc["cores_per_server"] == 9  # 0-8
+        assert alloc["servers"] == ["0-8"]
+
+    def test_request_based_base_carries_requests(self, request_based_config):
+        result = build_config(
+            request_based_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET key:__rand_int__",
+            data_size="16",
+            pipelines="1",
+        )
+        s = result[0]["test_groups"][0]["scenarios"][0]
+        assert s.get("requests") == 1000000
+        assert "duration" not in s  # never both, never a silent fallback
+
+    def test_generated_mixed_passes_validation(self, base_config):
+        result = build_config(
+            base_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET key:__rand_int__",
+            data_size="16,64",
+            pipelines="1,10",
+        )
+        # Final gate: the emitted config must satisfy the framework validator.
+        validate_config(copy.deepcopy(result[0]))  # should not raise
+
+    def test_input_not_mutated(self, base_config):
+        original = copy.deepcopy(base_config)
+        build_config(
+            base_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET key:__rand_int__",
+        )
+        assert base_config == original
+
+
+class TestMixedPredefinedWorkloads:
+    """WHEN a mixed side names a predefined command it SHALL emit a ``test:``
+    sub-scenario; an arbitrary string SHALL still emit ``command:``; the two
+    forms mix and match across sides."""
+
+    def test_predefined_pair_generates_test_subscenarios(self, base_config):
+        result = build_config(
+            base_config,
+            write_command="SET",
+            read_command="GET",
+            data_size="16",
+            pipelines="1",
+        )
+        s = result[0]["test_groups"][0]["scenarios"][0]
+        assert s["writes"] == [{"id": "w", "test": "SET", "clients": 800}]
+        assert s["reads"] == [{"id": "r", "test": "GET", "clients": 800}]
+        # A predefined side must NOT also carry an arbitrary command key.
+        assert "command" not in s["writes"][0]
+        assert "command" not in s["reads"][0]
+
+    def test_predefined_names_are_canonicalized_uppercase(self, base_config):
+        # Matches _parse_commands: a bare predefined token is upper-cased.
+        result = build_config(
+            base_config,
+            write_command="set",
+            read_command="get",
+            data_size="16",
+            pipelines="1",
+        )
+        s = result[0]["test_groups"][0]["scenarios"][0]
+        assert s["writes"][0]["test"] == "SET"
+        assert s["reads"][0]["test"] == "GET"
+
+    def test_arbitrary_pair_still_generates_command_subscenarios(self, base_config):
+        # Regression: multi-token strings remain arbitrary (command:) workloads.
+        result = build_config(
+            base_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET key:__rand_int__",
+            data_size="16",
+            pipelines="1",
+        )
+        s = result[0]["test_groups"][0]["scenarios"][0]
+        assert s["writes"] == [
+            {"id": "w", "command": "SET key:__rand_int__ __data__", "clients": 800}
+        ]
+        assert s["reads"] == [
+            {"id": "r", "command": "GET key:__rand_int__", "clients": 800}
+        ]
+        assert "test" not in s["writes"][0]
+        assert "test" not in s["reads"][0]
+
+    def test_predefined_write_arbitrary_read(self, base_config):
+        result = build_config(
+            base_config,
+            write_command="SET",
+            read_command="GET key:__rand_int__",
+            data_size="16",
+            pipelines="1",
+        )
+        s = result[0]["test_groups"][0]["scenarios"][0]
+        assert s["writes"][0] == {"id": "w", "test": "SET", "clients": 800}
+        assert s["reads"][0] == {
+            "id": "r",
+            "command": "GET key:__rand_int__",
+            "clients": 800,
+        }
+
+    def test_arbitrary_write_predefined_read(self, base_config):
+        result = build_config(
+            base_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET",
+            data_size="16",
+            pipelines="1",
+        )
+        s = result[0]["test_groups"][0]["scenarios"][0]
+        assert s["writes"][0] == {
+            "id": "w",
+            "command": "SET key:__rand_int__ __data__",
+            "clients": 800,
+        }
+        assert s["reads"][0] == {"id": "r", "test": "GET", "clients": 800}
+
+    def test_generated_predefined_mixed_passes_validation(self, base_config):
+        result = build_config(
+            base_config,
+            write_command="SET",
+            read_command="GET",
+            data_size="16,64",
+            pipelines="1,10",
+        )
+        # Final gate: a predefined-mixed config must satisfy the framework
+        # validator exactly as the arbitrary form does.
+        validate_config(copy.deepcopy(result[0]))  # should not raise
+
+
+class TestMixedRejections:
+    """WHEN mixed inputs conflict or are out of range, build_config SHALL raise
+    ConfigModificationError."""
+
+    _W = "SET key:__rand_int__ __data__"
+    _R = "GET key:__rand_int__"
+
+    @pytest.mark.parametrize(
+        "kwargs, match",
+        [
+            ({"write_command": _W}, "BOTH"),
+            ({"read_command": _R}, "BOTH"),
+            (
+                {"write_command": _W, "read_command": _R, "write_ratio": 0},
+                "between 1 and 99",
+            ),
+            (
+                {"write_command": _W, "read_command": _R, "write_ratio": 100},
+                "between 1 and 99",
+            ),
+            (
+                {"write_command": "GET", "read_command": "GET"},
+                "predefined READ command",
+            ),
+            (
+                {"write_command": "SET", "read_command": "SET"},
+                "predefined WRITE command",
+            ),
+            (
+                {"write_command": _W, "read_command": _R, "commands": "SET,GET"},
+                "cannot be combined with mixed",
+            ),
+            (
+                {"write_command": _W, "read_command": _R, "arbitrary_command": _R},
+                "cannot be combined with mixed",
+            ),
+            (
+                {"write_command": _W, "read_command": _R, "populate_command": _W},
+                "populate",
+            ),
+            (
+                {"write_command": "SET 'unterminated", "read_command": _R},
+                "write_command",
+            ),
+            (
+                {"write_command": _W, "read_command": "GET 'unterminated"},
+                "read_command",
+            ),
+        ],
+    )
+    def test_mixed_input_rejected(self, base_config, kwargs, match):
+        with pytest.raises(ConfigModificationError, match=match):
+            build_config(base_config, **kwargs)
+
+    def test_base_with_cpu_allocation_rejected(self, base_config):
+        cfg = copy.deepcopy(base_config)
+        del cfg[0]["server_cpu_range"]
+        del cfg[0]["client_cpu_range"]
+        cfg[0]["cpu_allocation"] = {"cores_per_server": 8, "cores_per_client": 8}
+        with pytest.raises(
+            ConfigModificationError, match="already defines cpu_allocation"
+        ):
+            build_config(
+                cfg,
+                write_command="SET key:__rand_int__ __data__",
+                read_command="GET key:__rand_int__",
+            )
+
+    def test_split_starving_a_side_rejected(self):
+        # A client pool too small to give both sides at least one connection.
+        tiny = [
+            {
+                "duration": 180,
+                "keyspacelen": [100],
+                "data_sizes": [16],
+                "pipelines": [1],
+                "clients": [1],
+                "commands": ["SET"],
+                "cluster_mode": False,
+                "tls_mode": False,
+                "warmup": 0,
+            }
+        ]
+        with pytest.raises(ConfigModificationError, match="at least one client"):
+            build_config(
+                tiny,
+                write_command="SET key:__rand_int__ __data__",
+                read_command="GET key:__rand_int__",
+                write_ratio=50,
+            )
+
+    def test_one_core_client_pool_rejected(self, base_config):
+        """Finding 2: a 1-core client pool cannot feed the two concurrent mixed
+        processes, so the script must reject it rather than clamp
+        cores_per_client to 1 and emit a config that raises at runtime."""
+        cfg = copy.deepcopy(base_config)
+        cfg[0]["client_cpu_range"] = "30"
+        with pytest.raises(ConfigModificationError, match="concurrent process"):
+            build_config(
+                cfg,
+                write_command="SET key:__rand_int__ __data__",
+                read_command="GET key:__rand_int__",
+            )
+
+    def test_mixed_against_scenario_format_base_rejected(self, scenario_format_config):
+        with pytest.raises(ConfigModificationError, match="scenario"):
+            build_config(
+                scenario_format_config,
+                write_command="SET key:__rand_int__ __data__",
+                read_command="GET key:__rand_int__",
+            )
+
+    def test_base_overlap_rejected_in_mixed(self, base_config):
+        """Case A: an overlap already in the base (server 0-3, client 3-6 share
+        core 3) SHALL be rejected in mixed mode too. The conversion folds the
+        ranges into cpu_allocation, and the effective-core check still fires."""
+        cfg = copy.deepcopy(base_config)
+        cfg[0]["server_cpu_range"] = "0-3"
+        cfg[0]["client_cpu_range"] = "3-6"
+        with pytest.raises(ConfigModificationError, match=r"overlap on cores: \[3\]"):
+            build_config(cfg, write_command=self._W, read_command=self._R)
+
+    def test_io_threads_widened_overlap_rejected_in_mixed(self, base_config):
+        """Case B: an overlap INTRODUCED during generation by --io-threads
+        widening the server range (base server 0-1, client 4-9; io-threads 8 ->
+        server 0-7) SHALL be rejected in mixed mode, naming all four shared
+        cores."""
+        cfg = copy.deepcopy(base_config)
+        cfg[0]["server_cpu_range"] = "0-1"
+        cfg[0]["client_cpu_range"] = "4-9"
+        with pytest.raises(
+            ConfigModificationError, match=r"overlap on cores: \[4, 5, 6, 7\]"
+        ):
+            build_config(
+                cfg, write_command=self._W, read_command=self._R, io_threads="8"
+            )
+
+    def test_non_overlapping_mixed_still_accepted(self, base_config):
+        """Guard against over-rejection: a normal mixed run with disjoint server
+        and client ranges (0-8 / 96-191, as in configs/benchmark-config-arm.json)
+        SHALL still be accepted after conversion."""
+        result = build_config(base_config, write_command=self._W, read_command=self._R)
+        assert result[0]["cpu_allocation"]["servers"] == ["0-8"]
+        assert result[0]["cpu_allocation"]["clients"] == ["96-191"]
+
+
+class TestMixedCli:
+    """WHEN invoked as a CLI, mixed flags SHALL produce a written mixed config."""
+
+    def test_mixed_cli_end_to_end(self, tmp_path, base_config):
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(base_config))
+        out = tmp_path / "out.json"
+        rc = main(
+            [
+                "--config",
+                str(path),
+                "--output",
+                str(out),
+                "--write-command",
+                "SET key:__rand_int__ __data__",
+                "--read-command",
+                "GET key:__rand_int__",
+                "--write-ratio",
+                "30",
+                "--data-size",
+                "64",
+                "--pipelines",
+                "1",
+            ]
+        )
+        assert rc == 0
+        written = json.loads(out.read_text())[0]
+        s = written["test_groups"][0]["scenarios"][0]
+        assert s["type"] == "mixed"
+        assert s["warmup_writes_only"] is True
+        assert s["writes"][0]["clients"] + s["reads"][0]["clients"] == 1600
+        assert written["cpu_allocation"]["cores_per_client"] == 48
+
+
+# ---------------------------------------------------------------------------
+# Mixed argv propagation and generated-scenario invariants
+# ---------------------------------------------------------------------------
+
+
+class TestFinding1MixedRequestArgv:
+    """A request-bounded mixed scenario produces children whose argv carries the
+    request count (-n) — for BOTH an arbitrary (command:) child and a predefined
+    (test:) child. Argv is built through ClientRunner."""
+
+    def test_both_children_carry_request_count_in_argv(self, request_based_config):
+        from valkey_benchmark import ClientRunner
+
+        result = build_config(
+            request_based_config,
+            write_command="SET key:__rand_int__ __data__",  # arbitrary -> command:
+            read_command="GET",  # predefined -> test:
+            data_size="16",
+            pipelines="1",
+        )
+        entry = result[0]
+        scenario = entry["test_groups"][0]["scenarios"][0]
+
+        runner = ClientRunner(
+            commit_id="abc123",
+            config=entry,
+            cluster_mode=False,
+            tls_mode=False,
+            target_ip="127.0.0.1",
+            results_dir=Path("/tmp/test_results"),
+            valkey_path="/tmp/valkey",
+            valkey_benchmark_path="src/valkey-benchmark",
+        )
+
+        writes, reads = runner._normalize_mixed_configs(scenario)
+        write_argv = runner._build_benchmark_command(writes[0], seed_val=1)
+        read_argv = runner._build_benchmark_command(reads[0], seed_val=1)
+
+        # Arbitrary (command:) child carries -n <requests>, never a duration.
+        assert "command" in writes[0]
+        assert "-n" in write_argv
+        assert write_argv[write_argv.index("-n") + 1] == "1000000"
+        assert "--duration" not in write_argv
+        # Predefined (test:) child carries -n <requests> too.
+        assert "test" in reads[0]
+        assert "-n" in read_argv
+        assert read_argv[read_argv.index("-n") + 1] == "1000000"
+        assert "--duration" not in read_argv
+
+
+class TestFinding4MixedClusterExecution:
+    """Generated mixed scenarios SHALL set cluster_execution single so
+    _launch_mixed_processes spawns one process per sub-scenario regardless of
+    node count."""
+
+    def test_generated_mixed_sets_cluster_execution_single(self, base_config):
+        result = build_config(
+            base_config,
+            write_command="SET key:__rand_int__ __data__",
+            read_command="GET key:__rand_int__",
+            data_size="16,64",
+            pipelines="1,10",
+        )
+        scenarios = result[0]["test_groups"][0]["scenarios"]
+        assert scenarios
+        assert all(s["cluster_execution"] == "single" for s in scenarios)
+
+
+class TestFinding5MultiValueCollapsed:
+    """A multi-element list in a field the generator collapses to one value
+    (clients/requests/keyspacelen) SHALL be rejected, not silently [0]."""
+
+    def test_multi_element_requests_rejected(self, request_based_config):
+        cfg = copy.deepcopy(request_based_config)
+        cfg[0]["requests"] = [111, 222]
+        with pytest.raises(ConfigModificationError, match="requests"):
+            build_config(
+                cfg,
+                arbitrary_command="GET key:__rand_int__",
+                data_size="16",
+                pipelines="1",
+            )
+
+    @pytest.mark.parametrize("field", ["keyspacelen", "clients"])
+    def test_multi_element_field_rejected(self, base_config, field):
+        cfg = copy.deepcopy(base_config)
+        cfg[0][field] = [100, 200]
+        with pytest.raises(ConfigModificationError, match=field):
+            build_config(
+                cfg,
+                arbitrary_command="GET key:__rand_int__",
+                data_size="16",
+                pipelines="1",
+            )
+
+
+class TestFinding6ScalarIoThreads:
+    """A scalar io-threads in the base SHALL be accepted (the framework
+    normalizes it); lists still work."""
+
+    def test_scalar_io_threads_accepted(self, base_config):
+        cfg = copy.deepcopy(base_config)
+        cfg[0]["io-threads"] = 1  # scalar, not a list
+        result = build_config(cfg, commands="SET")
+        assert result[0]["io-threads"] == 1
+
+
+class TestFinding7EmptyQuotedCommand:
+    """A command parsing to only empty tokens (e.g. '') SHALL be rejected across
+    arbitrary, populate, write and read commands."""
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"arbitrary_command": "''"},
+            {"arbitrary_command": "GET key:__rand_int__", "populate_command": "''"},
+            {"write_command": "''", "read_command": "GET key:__rand_int__"},
+            {"write_command": "SET key:__rand_int__ __data__", "read_command": "''"},
+        ],
+    )
+    def test_empty_quoted_rejected(self, base_config, kwargs):
+        with pytest.raises(ConfigModificationError, match="at least one token"):
+            build_config(base_config, **kwargs)
+
+
+class TestFinding8AllEntriesValidated:
+    """A malformed LATER entry SHALL raise ConfigModificationError, not a raw
+    TypeError from the final validation gate."""
+
+    def test_non_dict_later_entry_rejected(self, base_config):
+        cfg = copy.deepcopy(base_config)
+        cfg.append(42)  # entry [1] is not a dict
+        with pytest.raises(ConfigModificationError, match="entry \\[1\\]"):
+            build_config(cfg, commands="SET")
+
+
+class TestFinding9IntDigitLimit:
+    """An absurdly long digit string SHALL raise the script's error type, not
+    leak Python's integer string-conversion ValueError."""
+
+    def test_huge_data_size_rejected_cleanly(self, base_config):
+        with pytest.raises(ConfigModificationError):
+            build_config(base_config, data_size="9" * 5000)
+
+
+class TestFinding10DurationAndRequests:
+    """A base with BOTH duration and requests SHALL be rejected before
+    conversion, naming both fields (the arbitrary/mixed path deletes commands so
+    the framework's own commands-only check never runs)."""
+
+    def test_both_rejected_in_arbitrary_mode(self, base_config):
+        cfg = copy.deepcopy(base_config)
+        cfg[0]["requests"] = [1000000]  # base_config already sets duration=180
+        with pytest.raises(ConfigModificationError, match="duration.*requests"):
+            build_config(
+                cfg,
+                arbitrary_command="GET key:__rand_int__",
+                data_size="16",
+                pipelines="1",
+            )
+
+
+class TestFinding11SweepCap:
+    """The generated pipelines x data_sizes sweep SHALL be capped with a clear
+    error naming the limit; the cap is a parameter."""
+
+    def test_sweep_over_default_cap_rejected(self, base_config):
+        # 9 data sizes x 8 pipelines = 72 > default cap of 64.
+        with pytest.raises(ConfigModificationError, match="exceeding the limit"):
+            build_config(
+                base_config,
+                arbitrary_command="GET key:__rand_int__",
+                data_size="1,2,3,4,5,6,7,8,9",
+                pipelines="1,2,3,4,5,6,7,8",
+            )
+
+    def test_cap_is_a_parameter(self, base_config):
+        with pytest.raises(ConfigModificationError, match="limit of 2"):
+            build_config(
+                base_config,
+                arbitrary_command="GET key:__rand_int__",
+                data_size="16,64",
+                pipelines="1,10",
+                max_sweep_scenarios=2,
+            )
+
+    def test_within_cap_passes(self, base_config):
+        result = build_config(
+            base_config,
+            arbitrary_command="GET key:__rand_int__",
+            data_size="16,64",
+            pipelines="1,10",
+            max_sweep_scenarios=4,
+        )
+        assert len(result[0]["test_groups"][0]["scenarios"]) == 4
+
+
+class TestFinding12EmptyCommandName:
+    """The command NAME (first token) SHALL be non-empty; a later empty token is
+    a legitimate argument and stays allowed."""
+
+    @pytest.mark.parametrize("command", ["'' GET", '"" SET key value'])
+    def test_empty_command_name_rejected(self, base_config, command):
+        with pytest.raises(ConfigModificationError, match="command name"):
+            build_config(
+                base_config, arbitrary_command=command, data_size="16", pipelines="1"
+            )
+
+    def test_empty_trailing_argument_allowed(self, base_config):
+        # SET key '' — the empty token is an argument, not the command name.
+        result = build_config(
+            base_config,
+            arbitrary_command="SET key ''",
+            data_size="16",
+            pipelines="1",
+        )
+        scenario = result[0]["test_groups"][0]["scenarios"][0]
+        assert scenario["command"] == "SET key ''"

--- a/utils/compare_benchmark_results.py
+++ b/utils/compare_benchmark_results.py
@@ -30,8 +30,7 @@ except ImportError:
     np = None
     FuncFormatter = None
 
-# Central confidence level used for all CI/PI calculations and labels.
-# Change this single value to adjust the confidence level project-wide.
+# Shared by all CI/PI calculations and labels.
 CONFIDENCE_LEVEL = 0.95
 CONFIDENCE_PERCENT = int(CONFIDENCE_LEVEL * 100)
 
@@ -66,16 +65,7 @@ def calculate_stdev(values: List[float]) -> float:
 def calculate_confidence_interval(
     values: List[float], confidence_level: float = CONFIDENCE_LEVEL
 ) -> Tuple[float, float]:
-    """
-    Calculate confidence interval for a list of values using t-distribution.
-
-    Args:
-        values: List of numeric values
-        confidence_level: Confidence level (default CONFIDENCE_LEVEL)
-
-    Returns:
-        Tuple of (lower_bound, upper_bound) or (0.0, 0.0) if insufficient data
-    """
+    """Return a t-distribution confidence interval, or zeros for fewer than 2 values."""
     filtered_values = [v for v in values if v is not None]
     n = len(filtered_values)
 
@@ -85,7 +75,6 @@ def calculate_confidence_interval(
     mean_val = statistics.mean(filtered_values)
     stdev_val = statistics.stdev(filtered_values)
 
-    # Calculate standard error
     standard_error = stdev_val / (n**0.5)
 
     degrees_of_freedom = n - 1
@@ -98,19 +87,7 @@ def calculate_confidence_interval(
 def calculate_prediction_interval(
     values: List[float], confidence_level: float = CONFIDENCE_LEVEL
 ) -> Tuple[float, float]:
-    """
-    Calculate prediction interval for a single future observation using t-distribution.
-
-    Uses SciPy's t-distribution functions for accurate statistical calculations.
-    Reference: https://en.wikipedia.org/wiki/Student%27s_t-distribution#Prediction_interval
-
-    Args:
-        values: List of numeric values
-        confidence_level: Confidence level (default CONFIDENCE_LEVEL)
-
-    Returns:
-        Tuple of (lower_bound, upper_bound) or (0.0, 0.0) if insufficient data
-    """
+    """Return a t prediction interval, or zeros for fewer than 2 values."""
     filtered_values = [v for v in values if v is not None]
     n = len(filtered_values)
 
@@ -121,7 +98,6 @@ def calculate_prediction_interval(
     stdev_val = statistics.stdev(filtered_values)
 
     degrees_of_freedom = n - 1
-    # Prediction interval accounts for both sampling uncertainty and future observation variability
     prediction_scale = stdev_val * (1 + 1 / n) ** 0.5
 
     lower_bound, upper_bound = stats.t.interval(
@@ -133,16 +109,7 @@ def calculate_prediction_interval(
 def calculate_prediction_interval_percentage(
     values: List[float], confidence_level: float = CONFIDENCE_LEVEL
 ) -> float:
-    """
-    Calculate prediction interval as a percentage of the mean value.
-
-    Args:
-        values: List of numeric values
-        confidence_level: Confidence level (default CONFIDENCE_LEVEL)
-
-    Returns:
-        Prediction interval as percentage of mean (±X%), or 0.0 if insufficient data
-    """
+    """Return the prediction-interval margin as a percentage of the mean."""
     filtered_values = [v for v in values if v is not None]
     n = len(filtered_values)
 
@@ -155,7 +122,6 @@ def calculate_prediction_interval_percentage(
 
     stdev_val = statistics.stdev(filtered_values)
 
-    # Prediction interval uses sqrt(1 + 1/n) factor
     prediction_error = stdev_val * (1 + 1 / n) ** 0.5
 
     degrees_of_freedom = n - 1
@@ -163,25 +129,13 @@ def calculate_prediction_interval_percentage(
     t_critical = stats.t.ppf(1 - alpha / 2, degrees_of_freedom)
     margin_of_error = t_critical * prediction_error
 
-    # Calculate PI as percentage of mean
-    pi_percentage = (margin_of_error / mean_val) * 100.0
-
-    return pi_percentage
+    return (margin_of_error / mean_val) * 100.0
 
 
 def calculate_confidence_interval_percentage(
     values: List[float], confidence_level: float = CONFIDENCE_LEVEL
 ) -> float:
-    """
-    Calculate confidence interval as a percentage of the mean value.
-
-    Args:
-        values: List of numeric values
-        confidence_level: Confidence level (default CONFIDENCE_LEVEL)
-
-    Returns:
-        Confidence interval as percentage of mean (±X%), or 0.0 if insufficient data
-    """
+    """Return the confidence-interval margin as a percentage of the mean."""
     filtered_values = [v for v in values if v is not None]
     n = len(filtered_values)
 
@@ -192,33 +146,16 @@ def calculate_confidence_interval_percentage(
     if mean_val == 0.0:
         return 0.0
 
-    # Use the existing calculate_confidence_interval function
     ci_lower, ci_upper = calculate_confidence_interval(values, confidence_level)
-
-    # If confidence interval calculation failed, return 0.0
     if ci_lower == 0.0 and ci_upper == 0.0:
         return 0.0
-
-    # Calculate margin of error from the confidence interval bounds
     margin_of_error = (ci_upper - ci_lower) / 2.0
-
-    # Calculate CI as percentage of mean
-    ci_percentage = (margin_of_error / mean_val) * 100.0
-
-    return ci_percentage
+    return (margin_of_error / mean_val) * 100.0
 
 
-def discover_config_keys(data: List[Dict[str, Any]]) -> List[str]:
-    """
-    Dynamically discover configuration keys from benchmark data.
-
-    Excludes performance metrics and metadata fields, keeping only
-    configuration parameters that define test scenarios.
-    """
-    config_keys = set()
-
-    # Fields that are metrics or metadata, not configuration
-    excluded_fields = {
+# Metrics and run metadata excluded from both grouping and scenario identity.
+_CONFIG_EXCLUDED_FIELDS = frozenset(
+    {
         "timestamp",
         "commit",
         "module_commit",
@@ -278,10 +215,35 @@ def discover_config_keys(data: List[Dict[str, Any]]) -> List[str]:
         "p99_latency_ms_pi_upper",
         "p99_latency_ms_pi_percent",
     }
+)
+
+# Failure state and display-only fields do not identify a scenario. In particular,
+# success and failure rows may use different command labels.
+_NON_IDENTITY_FIELDS = _CONFIG_EXCLUDED_FIELDS | {
+    "status",
+    "error",
+    "command",
+    "group_description",
+    "scenario_description",
+}
+
+# Live readings may differ between compatible runs. Unknown environment fields
+# remain identity axes so new compatibility metadata is conservative by default.
+_VOLATILE_ENV_FIELDS = frozenset({"env_cpu_freq_mhz_at_setup"})
+
+
+def discover_config_keys(data: List[Dict[str, Any]]) -> List[str]:
+    """
+    Dynamically discover configuration keys from benchmark data.
+
+    Excludes performance metrics and metadata fields, keeping only
+    configuration parameters that define test scenarios.
+    """
+    config_keys = set()
 
     for item in data:
         for key, value in item.items():
-            if key not in excluded_fields:
+            if key not in _CONFIG_EXCLUDED_FIELDS and key not in _VOLATILE_ENV_FIELDS:
                 # Only include keys with hashable values for grouping
                 if isinstance(value, (str, int, float, bool, type(None))):
                     config_keys.add(key)
@@ -295,8 +257,10 @@ def discover_config_keys(data: List[Dict[str, Any]]) -> List[str]:
 
 
 def create_config_signature(item: Dict[str, Any], config_keys: List[str]) -> Tuple:
-    """Create a configuration signature tuple for grouping identical configurations."""
-    return tuple(item.get(key) for key in config_keys)
+    """Build a scalar signature plus a frozen ``config_set`` sweep value."""
+    config_set = item.get("config_set")
+    frozen_config_set = _make_hashable(config_set) if config_set else None
+    return tuple(item.get(key) for key in config_keys) + (frozen_config_set,)
 
 
 def group_by_command(items: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
@@ -336,35 +300,33 @@ def summarize_benchmark_results(data_items: List[Dict[str, Any]]) -> Dict[str, f
     }
 
 
-def average_multiple_runs(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """
-    Automatically average multiple benchmark runs with identical configurations.
-
-    Groups runs by configuration parameters and calculates means and standard deviations
-    for performance metrics. Always applied to ensure consistent comparisons.
-    """
+def average_multiple_runs(
+    data: List[Dict[str, Any]],
+    shared_config_keys: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Average runs with identical signatures using optional shared config keys."""
     if not data:
         return []
 
-    # Get configuration keys (excluding metrics and metadata)
+    base_keys = (
+        shared_config_keys
+        if shared_config_keys is not None
+        else discover_config_keys(data)
+    )
     config_keys = [
         key
-        for key in discover_config_keys(data)
+        for key in base_keys
         if key not in ["timestamp", "run_count"] and not key.endswith("_stdev")
     ]
 
-    # Group runs by identical configurations
     grouped_runs = {}
     for item in data:
         config_signature = create_config_signature(item, config_keys)
-        if config_signature not in grouped_runs:
-            grouped_runs[config_signature] = []
-        grouped_runs[config_signature].append(item)
+        grouped_runs.setdefault(config_signature, []).append(item)
 
     # Process each configuration group
     averaged_results = []
     for config_signature, runs in grouped_runs.items():
-        # Create base configuration item
         averaged_item = dict(zip(config_keys, config_signature))
         averaged_item["run_count"] = len(runs)
 
@@ -383,7 +345,6 @@ def average_multiple_runs(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             )
             averaged_results.append(single_run)
         else:
-            # Multiple runs: calculate averages and standard deviations
             metric_values = {
                 "rps": [run.get("rps", 0.0) for run in runs],
                 "avg_latency_ms": [run.get("avg_latency_ms", 0.0) for run in runs],
@@ -392,7 +353,6 @@ def average_multiple_runs(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 "p99_latency_ms": [run.get("p99_latency_ms", 0.0) for run in runs],
             }
 
-            # Calculate means, standard deviations, coefficient of variation, and confidence intervals
             for metric, values in metric_values.items():
                 mean_val = calculate_mean(values)
                 stdev_val = calculate_stdev(values)
@@ -400,27 +360,22 @@ def average_multiple_runs(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 averaged_item[metric] = mean_val
                 averaged_item[f"{metric}_stdev"] = stdev_val
 
-                # Calculate CV directly from already computed mean and stdev
                 if mean_val == 0.0 or stdev_val == 0.0:
                     averaged_item[f"{metric}_cv"] = 0.0
                 else:
                     averaged_item[f"{metric}_cv"] = (stdev_val / mean_val) * 100.0
 
-                # Calculate confidence interval
                 ci_lower, ci_upper = calculate_confidence_interval(values)
                 averaged_item[f"{metric}_ci_lower"] = ci_lower
                 averaged_item[f"{metric}_ci_upper"] = ci_upper
 
-                # Calculate confidence interval as percentage of mean
                 ci_percentage = calculate_confidence_interval_percentage(values)
                 averaged_item[f"{metric}_ci_percent"] = ci_percentage
 
-                # Calculate prediction interval
                 pi_lower, pi_upper = calculate_prediction_interval(values)
                 averaged_item[f"{metric}_pi_lower"] = pi_lower
                 averaged_item[f"{metric}_pi_upper"] = pi_upper
 
-                # Calculate prediction interval as percentage of mean
                 pi_percentage = calculate_prediction_interval_percentage(values)
                 averaged_item[f"{metric}_pi_percent"] = pi_percentage
 
@@ -429,26 +384,25 @@ def average_multiple_runs(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             if timestamps:
                 averaged_item["timestamp"] = max(timestamps)
 
-            # Preserve commit information from any run (they should all be the same)
             commits = [run.get("commit") for run in runs if run.get("commit")]
             if commits:
-                averaged_item["commit"] = commits[
-                    0
-                ]  # Use first commit (should be same for all runs)
+                averaged_item["commit"] = commits[0]
 
-            # Preserve module_commit information from any run
             module_commits = [
                 run.get("module_commit") for run in runs if run.get("module_commit")
             ]
             if module_commits:
                 averaged_item["module_commit"] = module_commits[0]
 
-            # Preserve repository information from any run
             repositories = [
                 run.get("repository") for run in runs if run.get("repository")
             ]
             if repositories:
                 averaged_item["repository"] = repositories[0]
+
+            # ``config_set`` is frozen outside ``config_keys``; retain its raw form.
+            if "config_set" in runs[0]:
+                averaged_item["config_set"] = runs[0]["config_set"]
 
             averaged_results.append(averaged_item)
 
@@ -463,14 +417,7 @@ def calculate_percentage_change(new_value: float, old_value: float) -> float:
 
 
 def create_config_sort_key(config_tuple: Tuple) -> Tuple[str, ...]:
-    """
-    Create a sorting key for configuration tuples that handles None values and mixed types.
-
-    Groups by test scenario first (test_id is hoisted to the front of the
-    config keys). Converts all values to strings for consistent comparison,
-    with None values sorting first. Note: sorting is lexicographic, so numeric
-    values embedded in strings sort as text (e.g. "10_get" before "2_get").
-    """
+    """Normalize mixed configuration values into a sortable string tuple."""
 
     def normalize_value(value):
         return "" if value is None else str(value)
@@ -519,28 +466,12 @@ def extract_version_identifier(data: List[Dict[str, Any]]) -> str:
 
 
 def extract_version_with_repo(data: List[Dict[str, Any]]) -> Tuple[str, Optional[str]]:
-    """
-    Extract version identifier and repository from benchmark data.
-
-    Returns:
-        Tuple of (version_string, repository) where repository may be None.
-    """
-    version = extract_version_identifier(data)
-    repository = None
-
-    if data:
-        repository = data[0].get("repository")
-
-    return version, repository
+    """Extract a version label and optional repository."""
+    return extract_version_identifier(data), data[0].get("repository") if data else None
 
 
 def format_version_link(version: str, repository: Optional[str]) -> str:
-    """
-    Format version as a GitHub link if repository is available.
-
-    Returns markdown link like [ec4462b](https://github.com/owner/repo/commit/ec4462b)
-    or just the version string if no repository.
-    """
+    """Link a version to its GitHub commit when a repository is available."""
     if repository:
         return f"[{version}](https://github.com/{repository}/commit/{version})"
     return version
@@ -548,32 +479,246 @@ def format_version_link(version: str, repository: Optional[str]) -> str:
 
 def group_by_static_configuration(
     data: List[Dict[str, Any]],
+    shared_config_keys: Optional[List[str]] = None,
 ) -> Dict[Tuple, Dict[str, Any]]:
-    """
-    Group benchmark results by static configuration parameters.
-
-    Excludes table-level parameters (command, pipeline, io_threads) that vary
-    within the same test configuration.
-    """
+    """Group rows by config, excluding command, pipeline, and I/O threads."""
     # Parameters that appear in the comparison table, not in config sections
     table_parameters = {"command", "pipeline", "io_threads"}
 
-    # Get configuration keys excluding table parameters
-    config_keys = [
-        key for key in discover_config_keys(data) if key not in table_parameters
-    ]
+    base_keys = (
+        shared_config_keys
+        if shared_config_keys is not None
+        else discover_config_keys(data)
+    )
+    config_keys = [key for key in base_keys if key not in table_parameters]
 
     grouped_configs = {}
     for item in data:
         config_signature = create_config_signature(item, config_keys)
-        if config_signature not in grouped_configs:
-            grouped_configs[config_signature] = {
-                "items": [],
-                "config_keys": config_keys,
-            }
+        grouped_configs.setdefault(
+            config_signature, {"items": [], "config_keys": config_keys}
+        )
         grouped_configs[config_signature]["items"].append(item)
 
     return grouped_configs
+
+
+# Performance metric fields that a comparable benchmark row is expected to carry.
+# A row missing every one of these is not numerically comparable (e.g. a failure
+# marker), but a row that merely holds a zero value still counts as comparable.
+_PERFORMANCE_METRIC_KEYS = (
+    "rps",
+    "avg_latency_ms",
+    "p50_latency_ms",
+    "p95_latency_ms",
+    "p99_latency_ms",
+)
+
+
+def is_failed_row(item: Dict[str, Any]) -> bool:
+    """Return whether a row is explicit failure or has no performance metrics."""
+    return item.get("status") == "failed" or not any(
+        key in item for key in _PERFORMANCE_METRIC_KEYS
+    )
+
+
+def partition_failed_rows(
+    data: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Split rows into ``(comparable, failed)`` using :func:`is_failed_row`."""
+    comparable: List[Dict[str, Any]] = []
+    failed: List[Dict[str, Any]] = []
+    for item in data:
+        (failed if is_failed_row(item) else comparable).append(item)
+    return comparable, failed
+
+
+def _make_hashable(value: Any) -> Any:
+    """Recursively freeze dictionaries and sequences for use in identity tuples."""
+    if isinstance(value, dict):
+        return tuple(sorted((str(k), _make_hashable(v)) for k, v in value.items()))
+    if isinstance(value, (list, tuple)):
+        return tuple(_make_hashable(v) for v in value)
+    return value
+
+
+def _scenario_identity(item: Dict[str, Any]) -> Optional[Tuple]:
+    """Return the structural scenario identity, or ``None`` for legacy rows.
+
+    All non-metric configuration and stable environment fields participate so
+    sweeps pair independently. Failure state, display labels, and volatile host
+    readings are excluded so matching success and failure rows still pair.
+    """
+    test_id = item.get("test_id")
+    if test_id is None:
+        return None
+    config_items = tuple(
+        sorted(
+            (key, _make_hashable(value))
+            for key, value in item.items()
+            if key != "test_id"
+            and key not in _NON_IDENTITY_FIELDS
+            and key not in _VOLATILE_ENV_FIELDS
+        )
+    )
+    return (test_id,) + config_items
+
+
+def _identity_set(data: List[Dict[str, Any]]) -> set:
+    """Return the distinct structural identities present in ``data``."""
+    return {
+        identity
+        for identity in (_scenario_identity(row) for row in data)
+        if identity is not None
+    }
+
+
+def _identities_compatible(left: Tuple, right: Tuple) -> bool:
+    """Return whether identities agree on every field they have in common."""
+    if left[0] != right[0]:
+        return False
+    left_fields = dict(left[1:])
+    right_fields = dict(right[1:])
+    if not (
+        left_fields.keys() <= right_fields.keys()
+        or right_fields.keys() <= left_fields.keys()
+    ):
+        return False
+    return all(
+        left_fields[key] == right_fields[key]
+        for key in left_fields.keys() & right_fields.keys()
+    )
+
+
+def _resolve_counterpart_identity(
+    identity: Optional[Tuple], own_ids: set, other_ids: set
+) -> Optional[Tuple]:
+    """Find an exact or unambiguous schema-compatible identity on the other side."""
+    if identity is None:
+        return None
+    if identity in other_ids:
+        return identity
+
+    candidates = [
+        candidate
+        for candidate in other_ids
+        if _identities_compatible(identity, candidate)
+    ]
+    if len(candidates) != 1:
+        return None
+
+    candidate = candidates[0]
+    reverse_candidates = [
+        own for own in own_ids if _identities_compatible(candidate, own)
+    ]
+    return candidate if reverse_candidates == [identity] else None
+
+
+def _paired_identity_key(identity: Optional[Tuple], counterpart: Optional[Tuple]):
+    """Build a shared report key for identities paired across schema versions."""
+    if identity is None or counterpart is None or identity == counterpart:
+        return identity
+    return ("__schema_pair__",) + tuple(sorted((identity, counterpart), key=repr))
+
+
+def _failed_scenario_ids(failed_rows: List[Dict[str, Any]]) -> set:
+    """Collect the non-None scenario identities from a list of failed rows."""
+    return {
+        identity
+        for identity in (_scenario_identity(row) for row in failed_rows)
+        if identity is not None
+    }
+
+
+def _primary_failed_metric(metrics_filter: str) -> Tuple[str, str]:
+    """Select the healthy counterpart value shown for a failed scenario."""
+    if metrics_filter == "latency":
+        return ("avg_latency_ms", "avg_latency")
+    return ("rps", "rps")
+
+
+def collect_failed_scenarios(
+    baseline_data: List[Dict[str, Any]],
+    new_data: List[Dict[str, Any]],
+    metrics_filter: str = "all",
+) -> List[Dict[str, Any]]:
+    """Describe failures and the matching healthy side's primary metric value."""
+    metric_key, metric_label = _primary_failed_metric(metrics_filter)
+
+    def index(data: List[Dict[str, Any]]) -> Tuple[Dict[Tuple, List[Dict]], set]:
+        comparable_by_id: Dict[Tuple, List[Dict[str, Any]]] = {}
+        present_ids = _identity_set(data)
+        for row in data:
+            identity = _scenario_identity(row)
+            if identity is None:
+                continue
+            if not is_failed_row(row):
+                comparable_by_id.setdefault(identity, []).append(row)
+        return comparable_by_id, present_ids
+
+    baseline_comparable, baseline_ids = index(baseline_data)
+    new_comparable, new_ids = index(new_data)
+
+    # Use all rows so a lone failed member of a sweep still names its varying axes.
+    identities_by_test: Dict[Any, List[Dict[str, Any]]] = {}
+    for row in baseline_data + new_data:
+        identity = _scenario_identity(row)
+        if identity is not None:
+            identities_by_test.setdefault(identity[0], []).append(dict(identity[1:]))
+    varying_axes = {
+        test_id: {
+            key
+            for key in set().union(*(fields.keys() for fields in identities))
+            if key != "test_phase"
+            if len({_make_hashable(fields.get(key)) for fields in identities}) > 1
+        }
+        for test_id, identities in identities_by_test.items()
+    }
+
+    descriptors: List[Dict[str, Any]] = []
+    for side, data, own_ids, other_comparable, other_ids in (
+        ("baseline", baseline_data, baseline_ids, new_comparable, new_ids),
+        ("new", new_data, new_ids, baseline_comparable, baseline_ids),
+    ):
+        _, failed = partition_failed_rows(data)
+        for row in failed:
+            identity = _scenario_identity(row)
+            display_axes = {
+                key: row.get(key) for key in varying_axes.get(row.get("test_id"), set())
+            }
+            if row.get("config_set"):
+                display_axes["config_set"] = row["config_set"]
+            counterpart_identity = _resolve_counterpart_identity(
+                identity, own_ids, other_ids
+            )
+            counterpart_rows = other_comparable.get(counterpart_identity, [])
+            counterpart_value = (
+                calculate_mean([r.get(metric_key) for r in counterpart_rows])
+                if counterpart_rows
+                else None
+            )
+            descriptors.append(
+                {
+                    "test_id": row.get("test_id"),
+                    "test_phase": row.get("test_phase"),
+                    "command": row.get("command"),
+                    "side": side,
+                    "error": row.get("error"),
+                    "counterpart_value": counterpart_value,
+                    "counterpart_present": counterpart_identity is not None,
+                    "metric_key": metric_key,
+                    "metric_label": metric_label,
+                    "identity": identity,
+                    "pairing_identity": _paired_identity_key(
+                        identity, counterpart_identity
+                    ),
+                    "config_set": row.get("config_set"),
+                    "cluster_mode": row.get("cluster_mode"),
+                    "io_threads": row.get("io_threads"),
+                    "display_axes": display_axes,
+                }
+            )
+    return descriptors
 
 
 def create_comparison_table_data(
@@ -590,9 +735,43 @@ def create_comparison_table_data(
     baseline_version, baseline_repo = extract_version_with_repo(baseline_data)
     new_version, new_repo = extract_version_with_repo(new_data)
 
-    # Group data by static configuration
-    baseline_configs = group_by_static_configuration(baseline_data)
-    new_configs = group_by_static_configuration(new_data)
+    baseline_comparable, baseline_failed = partition_failed_rows(baseline_data)
+    new_comparable, new_failed = partition_failed_rows(new_data)
+
+    # Exclude both sides of a failure; the report renders them separately.
+    baseline_ids = _identity_set(baseline_data)
+    new_ids = _identity_set(new_data)
+    baseline_failed_ids = _failed_scenario_ids(baseline_failed)
+    new_failed_ids = _failed_scenario_ids(new_failed)
+    baseline_excluded = set(baseline_failed_ids)
+    new_excluded = set(new_failed_ids)
+    for identity in new_failed_ids:
+        counterpart = _resolve_counterpart_identity(identity, new_ids, baseline_ids)
+        if counterpart is not None:
+            baseline_excluded.add(counterpart)
+    for identity in baseline_failed_ids:
+        counterpart = _resolve_counterpart_identity(identity, baseline_ids, new_ids)
+        if counterpart is not None:
+            new_excluded.add(counterpart)
+
+    if baseline_excluded or new_excluded:
+        baseline_comparable = [
+            row
+            for row in baseline_comparable
+            if _scenario_identity(row) not in baseline_excluded
+        ]
+        new_comparable = [
+            row for row in new_comparable if _scenario_identity(row) not in new_excluded
+        ]
+
+    # Both datasets must use the same signature key space.
+    shared_config_keys = discover_config_keys(baseline_comparable + new_comparable)
+
+    # Group data by static configuration using the shared key list
+    baseline_configs = group_by_static_configuration(
+        baseline_comparable, shared_config_keys
+    )
+    new_configs = group_by_static_configuration(new_comparable, shared_config_keys)
 
     # Define available metrics with their display names
     available_metrics = [
@@ -640,6 +819,15 @@ def create_comparison_table_data(
 
         # Create configuration dictionary for display
         config_dict = dict(zip(config_keys, config_signature))
+
+        # ``config_set`` is frozen outside scalar keys; restore it for display.
+        group_items = baseline_group["items"] or new_group["items"]
+        config_set_label = _format_config_set(
+            group_items[0].get("config_set") if group_items else None
+        )
+        if config_set_label:
+            config_keys = list(config_keys) + ["config_set"]
+            config_dict["config_set"] = config_set_label
 
         # Generate comparison table rows for this configuration
         table_rows = _generate_table_rows_for_config(
@@ -918,13 +1106,7 @@ def _extract_common_and_unique_config(
 def _generate_summary(
     config_groups: List[Dict],
 ) -> Tuple[List[Dict], List[Dict], int, int]:
-    """
-    Generate summary of significant findings from all config groups.
-
-    Returns:
-        Tuple of (improvements, regressions, no_change_count, insufficient_data_count)
-        where improvements and regressions are lists of dicts with test info and change.
-    """
+    """Collect significant changes and unchanged/insufficient counts."""
     improvements = []
     regressions = []
     no_change_count = 0
@@ -987,6 +1169,142 @@ def _generate_summary(
     return improvements, regressions, no_change_count, insufficient_data_count
 
 
+def _sanitize_table_cell(text: Optional[str]) -> str:
+    """Render untrusted text as a literal code span inside a Markdown table."""
+    if text is None:
+        return ""
+    s = str(text).replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
+    s = s.strip()
+    if not s:
+        return ""
+
+    # GitHub creates mentions and issue/email links after decoding character
+    # references. Code spans suppress that post-processing. Use a fence longer
+    # than any run in the value so embedded backticks cannot close the span.
+    longest_run = current_run = 0
+    for char in s:
+        current_run = current_run + 1 if char == "`" else 0
+        longest_run = max(longest_run, current_run)
+    fence = "`" * (longest_run + 1)
+
+    # GFM finds table separators before parsing inline code, so pipes still
+    # need a backslash at the table layer. The backslash is not displayed.
+    s = s.replace("|", r"\|")
+    return f"{fence} {s} {fence}"
+
+
+def _config_set_text(config_set: Optional[Dict[str, Any]]) -> str:
+    """Return sorted ``config_set`` key/value pairs as plain text."""
+    if not config_set:
+        return ""
+    return "; ".join(f"{k}={config_set[k]}" for k in sorted(config_set, key=str))
+
+
+def _format_config_set(config_set: Optional[Dict[str, Any]]) -> str:
+    """Render sorted ``config_set`` key/value pairs as literal text."""
+    return _sanitize_table_cell(_config_set_text(config_set))
+
+
+def _failed_side_cell(
+    own_entry: Optional[Dict[str, Any]],
+    other_entry: Optional[Dict[str, Any]],
+) -> str:
+    """Render ``FAILED``, the healthy counterpart value, or ``n/a``."""
+    if own_entry is not None:
+        return "**FAILED**"
+    if other_entry is None:
+        return "n/a"
+    value = other_entry.get("counterpart_value")
+    if value is None:
+        return "n/a"
+    label = other_entry.get("metric_label", "")
+    return _sanitize_table_cell(f"{_format_with_sig_figs(value)} {label}".strip())
+
+
+def _failed_error_cell(
+    baseline_entry: Optional[Dict[str, Any]],
+    new_entry: Optional[Dict[str, Any]],
+) -> str:
+    """Render one error, or side-prefixed errors when both sides failed."""
+    parts = []
+    if baseline_entry is not None:
+        parts.append(("baseline", baseline_entry.get("error")))
+    if new_entry is not None:
+        parts.append(("new", new_entry.get("error")))
+
+    def clean(err: Optional[str]) -> str:
+        return str(err).strip() if err else "no error recorded"
+
+    if len(parts) == 1:
+        error_text = clean(parts[0][1])
+    else:
+        error_text = "; ".join(f"{side}: {clean(err)}" for side, err in parts)
+    return _sanitize_table_cell(error_text)
+
+
+def _failed_scenario_label(descriptor: Dict[str, Any]) -> str:
+    """Render a scenario id plus config axes that distinguish failed rows."""
+    label = str(descriptor.get("test_id") or "unknown")
+    axis_bits: List[str] = []
+    aliases = {"cluster_mode": "cluster"}
+    for key, value in sorted(descriptor.get("display_axes", {}).items()):
+        if key == "config_set":
+            axis_bits.append(_config_set_text(value))
+        elif value is not None:
+            name = aliases.get(key, key)
+            axis_bits.append(f"{name}={value}")
+
+    if axis_bits:
+        label = f"{label} ({'; '.join(axis_bits)})"
+    return _sanitize_table_cell(label)
+
+
+def _format_failed_scenarios_section(
+    failed_scenarios: List[Dict[str, Any]],
+    baseline_version: str,
+    new_version: str,
+) -> List[str]:
+    """Render failures by full scenario identity as a two-sided table."""
+    grouped: Dict[Any, List[Dict[str, Any]]] = {}
+    for failure in failed_scenarios:
+        key = failure.get("pairing_identity", failure.get("identity"))
+        if key is None:
+            key = ("__no_id__", id(failure))
+        grouped.setdefault(key, []).append(failure)
+
+    lines = [
+        f"## ⚠️ {len(grouped)} failed scenario(s)",
+        "",
+        "Excluded from the numeric comparison (a failure has nothing to compare "
+        "against); the measured value is shown for whichever side succeeded:",
+        "",
+        f"| Scenario | Phase | Command | "
+        f"{_sanitize_table_cell(baseline_version)} | "
+        f"{_sanitize_table_cell(new_version)} | Error |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+
+    for entries in grouped.values():
+        baseline_entry = next((e for e in entries if e["side"] == "baseline"), None)
+        new_entry = next((e for e in entries if e["side"] == "new"), None)
+        sample = entries[0]
+
+        test_id = _failed_scenario_label(sample)
+        phase = _sanitize_table_cell(sample.get("test_phase"))
+        command = _sanitize_table_cell(sample.get("command"))
+        baseline_cell = _failed_side_cell(baseline_entry, new_entry)
+        new_cell = _failed_side_cell(new_entry, baseline_entry)
+        error_cell = _failed_error_cell(baseline_entry, new_entry)
+
+        lines.append(
+            f"| {test_id} | {phase} | {command} | "
+            f"{baseline_cell} | {new_cell} | {error_cell} |"
+        )
+
+    lines.append("")
+    return lines
+
+
 def format_comparison_report(
     config_groups: List[Dict],
     baseline_version: str,
@@ -995,15 +1313,10 @@ def format_comparison_report(
     new_repo: Optional[str] = None,
     core_commit_baseline: Optional[str] = None,
     core_commit_new: Optional[str] = None,
+    failed_scenarios: Optional[List[Dict[str, Any]]] = None,
 ) -> str:
-    """
-    Format the comparison data as a markdown report.
-
-    Structure:
-    - Summary at top (significant findings)
-    - Collapsible details section with full tables
-    """
-    if not config_groups:
+    """Format summary, failures, and comparison tables as Markdown."""
+    if not config_groups and not failed_scenarios:
         return "No data to compare."
 
     # Format version headers with links if repositories available
@@ -1055,6 +1368,13 @@ def format_comparison_report(
     if summary_parts:
         report_lines.append(f"*{', '.join(summary_parts)}*")
         report_lines.append("")
+
+    if failed_scenarios:
+        report_lines.extend(
+            _format_failed_scenarios_section(
+                failed_scenarios, baseline_version, new_version
+            )
+        )
 
     # Collapsible details section
     report_lines.append("<details>")
@@ -1207,31 +1527,17 @@ def _get_significance_indicator(
     change_percent: float,
     metric: str,
 ) -> str:
-    """
-    Determine significance indicator based on CI overlap.
-
-    Returns:
-        ✅ - Significant improvement (new CI above baseline CI)
-        ❌ - Significant regression (new CI below baseline CI)
-        ➖ - Not significant (CIs overlap)
-        ❔ - Insufficient data (either n <= 1)
-    """
-    # Insufficient data if either has only one run
+    """Classify CI overlap, accounting for whether lower values are better."""
     if baseline_run_count <= 1 or new_run_count <= 1:
         return "❔"
 
-    # For latency metrics, lower values are better (less delay)
-    # For throughput metrics (rps), higher values are better
     lower_is_better = "latency" in metric
 
-    # No overlap: new's lower bound > baseline's upper bound means new value increased
     if new_ci_lower > baseline_ci_upper:
         return "❌" if lower_is_better else "✅"
-    # No overlap: new's upper bound < baseline's lower bound means new value decreased
-    elif new_ci_upper < baseline_ci_lower:
+    if new_ci_upper < baseline_ci_lower:
         return "✅" if lower_is_better else "❌"
-    else:
-        return "➖"  # CIs overlap, not significant
+    return "➖"
 
 
 def calculate_percent_change_with_ci(
@@ -1242,16 +1548,7 @@ def calculate_percent_change_with_ci(
     baseline_run_count: int,
     new_run_count: int,
 ) -> Tuple[float, Optional[float]]:
-    """
-    Calculate percentage change with optional CI margin via uncertainty propagation.
-
-    Uses standard errors (σ/√n) for propagation through the ratio, then scales
-    by t-critical to produce a CI at CONFIDENCE_LEVEL.
-
-    Returns:
-        Tuple of (change_percent, ci_margin) where ci_margin is None when
-        there is insufficient data for uncertainty propagation.
-    """
+    """Return percentage change and an optional propagated CI margin."""
     if baseline_value == 0:
         return (0.0, None)
 
@@ -1322,13 +1619,7 @@ _UNIT_SUFFIXES = [
 
 
 def _format_with_sig_figs(value: float, uncertainty: float = 0.0) -> str:
-    """
-    Format a number with appropriate significant figures based on uncertainty.
-    Uses K/M/B/T suffixes for readability.
-
-    If uncertainty is provided, precision is determined by the uncertainty magnitude.
-    Otherwise, uses default precision.
-    """
+    """Format a value using uncertainty-aware precision and unit suffixes."""
     if value == 0:
         return "0"
 
@@ -1412,21 +1703,11 @@ def generate_comparison_graphs(
 
     # Collect all data for graphing
     all_rows = []
-    config_info = []
     for group in config_groups:
         all_rows.extend(group["table_rows"])
-        # Extract config info for legend
-        config_dict = group["config_dict"]
-        config_str = ", ".join(
-            [f"{k}={v}" for k, v in config_dict.items() if v is not None]
-        )
-        config_info.append(config_str)
 
     if not all_rows:
         return []
-
-    # Get unique config string for legends
-    unique_configs = list(set(config_info))
 
     # Generate single consolidated metrics comparison graph
     comprehensive_graph_path = generate_consolidated_metrics_graph(
@@ -1494,7 +1775,7 @@ def generate_variance_line_graphs(
             if graph_path:
                 generated_files.append(graph_path)
 
-    except Exception as e:
+    except Exception:
         pass  # Silently handle errors in graph generation
 
     return generated_files
@@ -1676,7 +1957,7 @@ def _generate_single_variance_graph(
 
         return str(graph_path)
 
-    except Exception as e:
+    except Exception:
         return None
 
 
@@ -1819,7 +2100,7 @@ def generate_consolidated_metrics_graph(
 
         return str(graph_path)
 
-    except Exception as e:
+    except Exception:
         return None
 
 
@@ -1922,9 +2203,18 @@ def main():
     baseline_data = load_benchmark_data(baseline_file)
     new_data = load_benchmark_data(new_file)
 
+    # Collect failed / non-comparable scenarios from the RAW rows (before
+    # averaging) so their recorded error text is preserved for the report. The
+    # metrics_filter selects which surviving-side metric to surface.
+    failed_scenarios = collect_failed_scenarios(baseline_data, new_data, metrics_filter)
+
+    # Union-based key discovery over both raw datasets, threaded into the
+    # run-averaging path so both sides group runs over an identical key space.
+    shared_config_keys = discover_config_keys(baseline_data + new_data)
+
     # Always apply dynamic averaging for consistent comparisons
-    baseline_data = average_multiple_runs(baseline_data)
-    new_data = average_multiple_runs(new_data)
+    baseline_data = average_multiple_runs(baseline_data, shared_config_keys)
+    new_data = average_multiple_runs(new_data, shared_config_keys)
 
     # Generate comparison data
     config_groups, baseline_version, new_version, baseline_repo, new_repo = (
@@ -1968,6 +2258,7 @@ def main():
         new_repo,
         core_commit_baseline=core_commit_baseline,
         core_commit_new=core_commit_new,
+        failed_scenarios=failed_scenarios,
     )
 
     # Create final report with metadata

--- a/utils/cpu_utils.py
+++ b/utils/cpu_utils.py
@@ -79,6 +79,26 @@ def validate_explicit_cpu_ranges(server_range: str, client_range: str) -> None:
         )
 
 
+def format_core_list(cores: List[int]) -> str:
+    """Render core IDs as a taskset-compatible string (inverse of parse_core_range).
+
+    Consecutive runs collapse to "a-b", isolated cores stay bare, and parts join
+    with commas (e.g. [11, 20, 21] -> "11,20-21"). Order is preserved as given.
+    """
+    if not cores:
+        raise ValueError("Cannot format an empty core list")
+    parts = []
+    run_start = prev = cores[0]
+    for core in cores[1:]:
+        if core == prev + 1:
+            prev = core
+            continue
+        parts.append(f"{run_start}-{prev}" if prev > run_start else str(run_start))
+        run_start = prev = core
+    parts.append(f"{run_start}-{prev}" if prev > run_start else str(run_start))
+    return ",".join(parts)
+
+
 def parse_core_range(range_str: str) -> List[int]:
     """Parse CPU core range string to list of core IDs.
 

--- a/utils/modify_config.py
+++ b/utils/modify_config.py
@@ -1,0 +1,1054 @@
+"""Modify a benchmark config from named parameters supplied via a workflow form.
+
+Output is validated through the framework's ``validate_config`` before writing.
+CLI flags mirror the workflow input names. Three modes:
+
+* Predefined-command mode overrides ``commands``, ``data_sizes``,
+  ``pipelines``, ``io-threads``, ``cluster_mode`` and ``benchmark-threads`` on
+  the first config entry.
+* Arbitrary-command mode replaces those predefined fields with a generated
+  ``test_groups`` block: one scenario per ``pipeline x data_size``, each
+  optionally carrying a ``populate_with`` write command.
+* Mixed mode (``--write-command`` + ``--read-command``) generates ``type:
+  "mixed"`` scenarios (one per ``pipeline x data_size``) whose write and read
+  sides run concurrently, split by ``--write-ratio``, and derives a
+  ``cpu_allocation`` partitioning the client CPU pool across the two processes.
+  Each side accepts EITHER a predefined command name (a bare token in
+  READ/WRITE_COMMANDS, emitted as ``-t NAME``) or an arbitrary command string
+  (emitted after ``--``); the two forms can be mixed across sides.
+
+Flag classification (see ``build_config``): ``--commands``, ``--data-size``,
+``--pipelines``, ``--arbitrary-command`` and ``--populate-command`` are
+predefined-only (require a commands-format base; in arbitrary/mixed mode
+``--data-size``/``--pipelines`` are the scenario sweep). ``--cluster-mode``,
+``--io-threads`` and ``--benchmark-threads`` are entry-level and apply to a
+scenario-format base too.
+"""
+
+import argparse
+import copy
+import json
+import re
+import shlex
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+# Allow ``python utils/modify_config.py`` to import the framework modules that
+# live at the repository root (mirrors tests/conftest.py path bootstrap).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmark import validate_config
+from utils.cpu_utils import parse_core_range
+from valkey_benchmark import READ_COMMANDS, WRITE_COMMANDS
+
+# ---------- Framework/protocol bounds (not machine-specific) -----------------
+MAX_COMMAND_LENGTH = 512
+DATA_SIZE_MIN = 1
+DATA_SIZE_MAX = 1048576  # 1 MiB payload ceiling
+PIPELINE_MIN = 1
+PIPELINE_MAX = 1000
+
+# A mixed scenario runs its write and read sides as two concurrent processes,
+# so the client CPU pool is split two ways when deriving cores_per_client.
+MIXED_CONCURRENT_PROCESSES = 2
+
+# ---------- Machine-specific bounds (CLI-parameterised, with defaults) -------
+# Defaults reproduce the on-demand workflow's runner (20-CPU NUMA node, 96-CPU
+# client pool); they are CLI parameters because they describe the runner host.
+DEFAULT_SERVER_CPU_CEILING = 19  # max index for the derived server_cpu_range
+DEFAULT_MAX_IO_THREADS = 20  # CPUs available on the server NUMA node
+DEFAULT_MAX_BENCHMARK_THREADS = 96  # size of the client CPU pool
+DEFAULT_MAX_SWEEP_SCENARIOS = 64  # ceiling on generated pipelines x data_sizes
+
+
+class ConfigModificationError(ValueError):
+    """Raised when inputs are invalid or the generated config is rejected."""
+
+
+# ---------- Input parsing / validation ---------------------------------------
+
+
+def _reject_duplicates(values: list, name: str) -> None:
+    """Reject a list that repeats a value (a duplicate is almost always a typo)."""
+    if len(set(values)) != len(values):
+        dupes = sorted({v for v in values if values.count(v) > 1}, key=values.index)
+        raise ConfigModificationError(
+            f"{name} contains duplicate values {dupes}; each value must be unique."
+        )
+
+
+def _to_bounded_int(token: str, name: str, low: int, high: int) -> int:
+    """Convert a digit string to an int in ``[low, high]``.
+
+    Wraps Python's integer string-conversion digit-limit ValueError (raised for
+    absurdly long digit strings) in the script's own error type.
+    """
+    if not re.fullmatch(r"[0-9]+", token):
+        raise ConfigModificationError(
+            f"{name} values must be integers between {low} and {high}. Got: {token}"
+        )
+    try:
+        number = int(token)
+    except ValueError as exc:
+        raise ConfigModificationError(f"{name} value {token[:12]}… is unusable: {exc}")
+    if not (low <= number <= high):
+        raise ConfigModificationError(
+            f"{name} values must be integers between {low} and {high}. Got: {token}"
+        )
+    return number
+
+
+def _parse_csv_list(raw: str, name: str, convert) -> Optional[list]:
+    """Parse a comma list, rejecting empty components and duplicates.
+
+    ``convert(token)`` maps each stripped token to its stored value (a bounded
+    int or an upper-cased command name) or raises. Returns ``None`` for an
+    empty/absent input (the workflow's "empty means use the config default").
+    """
+    if raw is None or not raw.strip():
+        return None
+    values = []
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            raise ConfigModificationError(
+                f"{name} has an empty component; remove stray commas. Got: {raw!r}"
+            )
+        values.append(convert(token))
+    _reject_duplicates(values, name)
+    return values
+
+
+def _parse_int_list(raw: str, name: str, low: int, high: int) -> Optional[List[int]]:
+    """Parse a comma-separated integer list, bounds-checking each value."""
+    return _parse_csv_list(
+        raw, name, lambda token: _to_bounded_int(token, name, low, high)
+    )
+
+
+def _parse_benchmark_threads(raw: str, high: int) -> Optional[int]:
+    """Parse the single benchmark-threads value, bounded by the client pool."""
+    if raw is None or not raw.strip():
+        return None
+    return _to_bounded_int(raw.strip(), "benchmark_threads", 1, high)
+
+
+def _parse_commands(raw: str) -> Optional[List[str]]:
+    """Parse comma-separated predefined commands, upper-cased and allowlisted
+    against the framework's own READ_COMMANDS/WRITE_COMMANDS."""
+    commands = _parse_csv_list(raw, "commands", str.upper)
+    if commands is None:
+        return None
+    supported = READ_COMMANDS + WRITE_COMMANDS
+    for command in commands:
+        if command not in supported:
+            raise ConfigModificationError(
+                f"Unsupported command: {command}. Supported commands: "
+                f"{', '.join(supported)}"
+            )
+    return commands
+
+
+def _validate_command_string(command: str, label: str) -> None:
+    """Reject a malformed arbitrary/populate command at script time.
+
+    Rejects multi-line and over-length strings, and parses the command with
+    ``shlex.split`` so unmatched quotes, trailing backslashes and empty commands
+    fail here rather than only after the benchmark process starts.
+    """
+    if "\n" in command:
+        raise ConfigModificationError(f"{label} must be a single line.")
+    if len(command) > MAX_COMMAND_LENGTH:
+        raise ConfigModificationError(
+            f"{label} must be at most {MAX_COMMAND_LENGTH} characters."
+        )
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        raise ConfigModificationError(
+            f"{label} is not a parseable command ({exc}): {command!r}"
+        )
+    # ``all(...)`` catches both an empty list and a list of only empty tokens:
+    # shlex.split("''") yields [''], which is not caught by ``not tokens``.
+    if all(not token for token in tokens):
+        raise ConfigModificationError(
+            f"{label} must contain at least one token. Got: {command!r}"
+        )
+    # The command NAME is the first token; an empty one (e.g. "'' GET") is
+    # unrunnable even when later argument tokens are present.
+    if not tokens[0]:
+        raise ConfigModificationError(
+            f"{label} command name (first token) must be non-empty. Got: {command!r}"
+        )
+
+
+def _classify_mixed_workload(value: str, *, side: str) -> tuple:
+    """Classify a mixed write/read side, returning ``("test", NAME)`` or
+    ``("command", value)``.
+
+    A single bare token that is a framework predefined command becomes a
+    ``test:`` workload (``-t NAME``, upper-cased like --commands); anything else
+    is an arbitrary ``command:`` string (run after ``--``). A predefined name is
+    rejected on the wrong side (a READ on the write side, or vice versa) because
+    the write side seeds the keyspace the read side queries; an arbitrary string
+    is opaque and only held to the command-string parseability rules.
+    """
+    predefined = READ_COMMANDS + WRITE_COMMANDS
+    side_allowlist = WRITE_COMMANDS if side == "write" else READ_COMMANDS
+    label = f"{side}_command"
+
+    try:
+        tokens = shlex.split(value)
+    except ValueError:
+        tokens = None  # malformed -> arbitrary; _validate_command_string reports it
+
+    if tokens is not None and len(tokens) == 1 and tokens[0].upper() in predefined:
+        name = tokens[0].upper()
+        if name not in side_allowlist:
+            other = "read" if side == "write" else "write"
+            raise ConfigModificationError(
+                f"--{side}-command {value!r} is a predefined {other.upper()} "
+                f"command, but the mixed {side} side must be a {side.upper()} "
+                f"workload. Predefined {side} commands: "
+                f"{', '.join(side_allowlist)}. (Supply an arbitrary command "
+                "string to run this command on the "
+                f"{side} side regardless.)"
+            )
+        return "test", name
+
+    # Arbitrary command string: held to the same parseability rules as
+    # --arbitrary-command (single line, length, shlex-parseable, non-empty).
+    _validate_command_string(value, label)
+    return "command", value
+
+
+def _derive_server_cpu_range(io_threads: List[int], ceiling: int) -> str:
+    """Derive ``0-(max_io_threads - 1)`` capped at the runner CPU ceiling."""
+    end = max(io_threads) - 1
+    if end > ceiling:
+        end = ceiling
+    return f"0-{end}"
+
+
+# ---------- Base-config shape / mode validation ------------------------------
+
+# List-valued base fields the script reads by index or iterates; shape is
+# validated up front so a bad field raises ConfigModificationError, not a raw
+# AttributeError/TypeError deep in generation.
+_LIST_FIELDS = (
+    "commands",
+    "data_sizes",
+    "pipelines",
+    "io-threads",
+    "clients",
+    "keyspacelen",
+    "requests",
+)
+
+# Flags that patch entry-level keys and therefore apply to ANY base, including
+# one already in scenario (test_groups) format. Everything else is
+# predefined-only: it edits or replaces commands/data_sizes/pipelines, which a
+# scenario-format base does not have.
+UNIVERSAL_FLAGS = ("--cluster-mode", "--io-threads", "--benchmark-threads")
+
+
+def _validate_base_shape(base_configs) -> None:
+    """Validate every base entry's shape before any field is read.
+
+    Guarantees callers see one exception type: a non-empty list of dicts whose
+    list-valued fields are actually lists. ``io-threads`` may also be a scalar
+    int, which the framework normalizes. Every entry is checked (not just entry
+    0) so a malformed later entry raises ConfigModificationError.
+    """
+    if not isinstance(base_configs, list) or not base_configs:
+        raise ConfigModificationError("Config must be a non-empty JSON array.")
+    for index, entry in enumerate(base_configs):
+        if not isinstance(entry, dict):
+            raise ConfigModificationError(
+                f"Config entry [{index}] must be a JSON object."
+            )
+        for key in _LIST_FIELDS:
+            value = entry.get(key)
+            if value is None:
+                continue
+            # A scalar io-threads is valid; the framework normalizes it.
+            if (
+                key == "io-threads"
+                and isinstance(value, int)
+                and not isinstance(value, bool)
+            ):
+                continue
+            if not isinstance(value, list):
+                raise ConfigModificationError(
+                    f"base config entry [{index}] field {key!r} must be a list."
+                )
+
+
+def _validate_run_bound_exclusive(entry: dict) -> None:
+    """Reject a base entry that sets BOTH ``duration`` and ``requests``.
+
+    ``validate_config`` forbids this only in its ``has_commands`` branch, but the
+    arbitrary/mixed conversion deletes ``commands`` before validating, so the
+    conflict would otherwise escape. Checked before conversion.
+    """
+    if entry.get("duration") is not None and entry.get("requests") is not None:
+        raise ConfigModificationError(
+            "base config entry sets both 'duration' and 'requests'; they are "
+            "mutually exclusive. Supply exactly one."
+        )
+
+
+def _is_scenario_format(entry: dict) -> bool:
+    """Return True when entry 0 is already in scenario (test_groups) format."""
+    return "test_groups" in entry or "scenarios" in entry
+
+
+def _effective_cpu_cores(entry: dict) -> tuple:
+    """Return the effective ``(server_cores, client_cores)`` sets for an entry.
+
+    Reads ``cpu_allocation.servers``/``clients`` (lists of range strings) when a
+    cpu_allocation block is present, otherwise ``server_cpu_range``/
+    ``client_cpu_range``, so the overlap check sees the same cores the runner
+    pins even after mixed conversion folds the explicit ranges into
+    cpu_allocation.
+    """
+    alloc = entry.get("cpu_allocation")
+    if alloc is not None:
+        server_ranges = alloc.get("servers", [])
+        client_ranges = alloc.get("clients", [])
+    else:
+        server_ranges = (
+            [entry["server_cpu_range"]] if "server_cpu_range" in entry else []
+        )
+        client_ranges = (
+            [entry["client_cpu_range"]] if "client_cpu_range" in entry else []
+        )
+
+    def _flatten(ranges: list) -> set:
+        cores: set = set()
+        for range_str in ranges:
+            cores.update(parse_core_range(range_str))
+        return cores
+
+    return _flatten(server_ranges), _flatten(client_ranges)
+
+
+def _validate_cpu_config(entry: dict, index: int) -> None:
+    """Reject CPU configuration conflicts detectable from the config alone.
+
+    Catches two conflicts that pass ``validate_config`` but fail at benchmark
+    startup: ``cpu_allocation`` coexisting with explicit ``server_cpu_range``/
+    ``client_cpu_range`` (which an io-threads override can itself create), and an
+    overlap between the effective server and client cores — resolved via
+    ``_effective_cpu_cores`` so mixed conversion (which folds the ranges into
+    cpu_allocation) cannot bypass it. It deliberately does NOT check total cores
+    against the host CPU count: this script runs on a different machine than the
+    benchmark, so that check would reject valid configs.
+    """
+    has_alloc = "cpu_allocation" in entry
+    has_server = "server_cpu_range" in entry
+    has_client = "client_cpu_range" in entry
+
+    if has_alloc and (has_server or has_client):
+        raise ConfigModificationError(
+            f"generated config entry [{index}] has cpu_allocation together with "
+            "server_cpu_range/client_cpu_range; they are mutually exclusive. "
+            "(An --io-threads override derives server_cpu_range, which conflicts "
+            "with a base that already defines cpu_allocation.)"
+        )
+
+    try:
+        server_cores, client_cores = _effective_cpu_cores(entry)
+    except ValueError as exc:
+        raise ConfigModificationError(
+            f"generated config entry [{index}] has an invalid CPU range: {exc}"
+        )
+    overlap = server_cores & client_cores
+    if overlap:
+        raise ConfigModificationError(
+            f"generated config entry [{index}] server and client CPU ranges "
+            f"overlap on cores: {sorted(overlap)}"
+        )
+
+
+# ---------- Scenario generation ----------------------------------------------
+
+# Base fields the generated scenarios collapse to a single value: the script
+# reads clients/requests via [0], and the framework reads keyspacelen[0] for a
+# generated scenario. A multi-element list here almost certainly means the
+# operator expected a sweep the generator does not perform.
+_SINGLE_VALUE_FIELDS = ("clients", "requests", "keyspacelen")
+
+
+def _reject_multi_value_fields(entry: dict) -> None:
+    """Reject multi-element lists in fields collapsed to one value."""
+    for field in _SINGLE_VALUE_FIELDS:
+        value = entry.get(field)
+        if isinstance(value, list) and len(value) > 1:
+            raise ConfigModificationError(
+                f"base config entry {field!r} has {len(value)} values {value}; "
+                f"generated scenarios use a single {field} value, so a "
+                "multi-element list would silently use only the first. Supply "
+                "exactly one."
+            )
+
+
+def _check_sweep_size(pipelines: List[int], data_sizes: List[int], limit: int) -> None:
+    """Cap the generated ``pipelines x data_sizes`` sweep."""
+    count = len(pipelines) * len(data_sizes)
+    if count > limit:
+        raise ConfigModificationError(
+            f"generated sweep would create {count} scenarios ({len(pipelines)} "
+            f"pipelines x {len(data_sizes)} data sizes), exceeding the limit of "
+            f"{limit}. Reduce --pipelines/--data-size or raise "
+            "--max-sweep-scenarios."
+        )
+
+
+def _run_bound(base: dict) -> dict:
+    """Return the single run bound (``duration`` OR ``requests``) for a generated
+    scenario, preserving the framework's duration-over-requests precedence.
+
+    A base with neither is rejected: the runner would otherwise silently fall
+    back to a 60-second run and discard the configured request count.
+    """
+    if base.get("duration") is not None:
+        return {"duration": base["duration"]}
+    if base.get("requests"):
+        return {"requests": base["requests"][0]}
+    raise ConfigModificationError(
+        "base config entry must define 'duration' or 'requests' for generated "
+        "scenarios; neither is set and the runner would silently fall back to a "
+        "60-second run."
+    )
+
+
+def _iter_sweep(prefix: str, pipelines: List[int], data_sizes: List[int]):
+    """Yield ``(scenario_id, pipeline, data_size)`` per pipeline x data_size.
+
+    Shared id construction for the arbitrary and mixed builders.
+    """
+    for data_size in data_sizes:
+        for pipeline in pipelines:
+            yield f"{prefix}_p{pipeline}_d{data_size}", pipeline, data_size
+
+
+def _resolve_sweep(entry: dict, pipeline_list, data_sizes, max_sweep: int):
+    """Resolve and validate the pipelines x data_sizes sweep for a generated mode.
+
+    Sweep comes from --pipelines/--data-size or the base's own values (read
+    before the predefined fields are removed). Applies the single-value and
+    sweep-size guards, then removes the predefined fields the generated
+    ``test_groups`` replaces. Shared by arbitrary and mixed.
+    """
+    scenario_pipelines = (
+        pipeline_list if pipeline_list is not None else entry.get("pipelines")
+    )
+    scenario_sizes = data_sizes if data_sizes is not None else entry.get("data_sizes")
+    if not scenario_pipelines or not scenario_sizes:
+        raise ConfigModificationError(
+            "generated scenarios need pipelines and data_sizes, from "
+            "--pipelines/--data-size or the base config entry."
+        )
+    if not entry.get("clients"):
+        raise ConfigModificationError(
+            "base config entry must define 'clients' for scenario generation."
+        )
+    _reject_multi_value_fields(entry)
+    _check_sweep_size(scenario_pipelines, scenario_sizes, max_sweep)
+    for key in ("commands", "data_sizes", "pipelines"):
+        entry.pop(key, None)
+    return scenario_pipelines, scenario_sizes
+
+
+def _build_arbitrary_group(
+    base: dict,
+    command: str,
+    populate_command: str,
+    pipelines: List[int],
+    data_sizes: List[int],
+) -> List[dict]:
+    """Build the ``test_groups`` block for an arbitrary command (one scenario per
+    pipeline x data_size).
+
+    A populate command is attached to each scenario as ``populate_with`` (not a
+    separate write scenario) so the framework threads ONE seed through both the
+    populate pass and the main run and they hit the same keys.
+    """
+    clients = base["clients"][0]
+    run_bound = _run_bound(base)
+
+    scenarios = []
+    for scenario_id, pipeline, data_size in _iter_sweep("cmd", pipelines, data_sizes):
+        scenario = {
+            "id": scenario_id,
+            "type": "arbitrary",
+            "command": command,
+            "clients": clients,
+            "pipeline": pipeline,
+            "data_size": data_size,
+            "warmup": base.get("warmup", 0),
+            **run_bound,
+        }
+        if populate_command:
+            scenario["populate_with"] = populate_command
+        scenarios.append(scenario)
+    return [{"group": 1, "description": "arbitrary command", "scenarios": scenarios}]
+
+
+def _validate_mixed_inputs(
+    write_command: str,
+    read_command: str,
+    write_ratio: int,
+    commands: str,
+    arbitrary_command: str,
+    populate_command: str,
+    entry: dict,
+) -> None:
+    """Reject conflicting or out-of-range inputs for mixed mode.
+
+    Mixed mode (BOTH write and read commands) is mutually exclusive with the
+    predefined/arbitrary/populate flags, requires a 1..99 write ratio, and needs
+    a base without its own cpu_allocation (it derives one). See the individual
+    checks for the exact rules.
+    """
+    if not (write_command and read_command):
+        raise ConfigModificationError(
+            "mixed mode needs BOTH --write-command and --read-command; supplying "
+            "only one is ambiguous. For a single command use --arbitrary-command."
+        )
+    if commands:
+        raise ConfigModificationError(
+            "--commands cannot be combined with mixed mode (--write-command/"
+            "--read-command); mixed generates its own scenarios. Supply only one."
+        )
+    if arbitrary_command:
+        raise ConfigModificationError(
+            "--arbitrary-command cannot be combined with mixed mode "
+            "(--write-command/--read-command); supply only one."
+        )
+    if populate_command:
+        raise ConfigModificationError(
+            "--populate-command cannot be combined with mixed mode; the mixed "
+            "write side seeds the keyspace, and the framework rejects "
+            "'populate_with' on a mixed scenario."
+        )
+    if not (1 <= write_ratio <= 99):
+        raise ConfigModificationError(
+            f"--write-ratio must be between 1 and 99 (got {write_ratio}); 0 or "
+            "100 is not a mixed load — use --arbitrary-command for a single "
+            "command."
+        )
+    if "cpu_allocation" in entry:
+        raise ConfigModificationError(
+            "mixed mode derives cpu_allocation from the base's client_cpu_range "
+            "to split the client CPU pool between its concurrent write and read "
+            "processes, but the base already defines cpu_allocation. Supply a "
+            "base that uses server_cpu_range/client_cpu_range, or remove "
+            "cpu_allocation."
+        )
+    # Classify each side now so bad side-placement fails early with an
+    # actionable error; the result is recomputed in _build_mixed_group.
+    _classify_mixed_workload(write_command, side="write")
+    _classify_mixed_workload(read_command, side="read")
+
+
+def _split_clients(total: int, write_ratio: int) -> tuple:
+    """Split ``total`` client connections into ``(write, read)`` by percent.
+
+    The write side is floored and the read side takes the remainder, so the two
+    always sum to ``total`` EXACTLY — flooring both would silently drop
+    connections. Both sides must receive at least one client; a ratio/total that
+    would starve either side is rejected rather than emitting a zero-client
+    sub-scenario the runner cannot execute.
+    """
+    write_clients = total * write_ratio // 100
+    read_clients = total - write_clients  # reads absorb the rounding remainder
+    if write_clients < 1 or read_clients < 1:
+        raise ConfigModificationError(
+            f"--write-ratio {write_ratio} splits {total} client(s) into "
+            f"{write_clients} write / {read_clients} read; each side needs at "
+            "least one client. Raise the base 'clients' or move the ratio "
+            "toward 50."
+        )
+    return write_clients, read_clients
+
+
+def _apply_mixed_cpu_allocation(entry: dict) -> None:
+    """Repartition the base's client CPU pool across the mixed processes.
+
+    Emits the *manual* (servers/clients arrays) cpu_allocation form, not the
+    auto form: the auto form collapses the pool to a single
+    ``cores_per_client``-wide block that the second mixed process overruns,
+    whereas the manual form preserves the operator's exact core placement while
+    ``cores_per_client = pool // processes`` hands each process its own slice
+    (e.g. 96-191 -> 96-143 write, 144-191 read). The explicit
+    ``server_cpu_range``/``client_cpu_range`` are folded into the arrays and
+    removed so the mutually-exclusive-CPU invariant still holds.
+    """
+    client_range = entry.get("client_cpu_range")
+    if not client_range:
+        # No client pool to partition; leave pinning to the runner defaults.
+        return
+
+    pool_size = len(parse_core_range(client_range))
+    cores_per_client = max(1, pool_size // MIXED_CONCURRENT_PROCESSES)
+    needed = MIXED_CONCURRENT_PROCESSES * cores_per_client
+    if pool_size < needed:
+        raise ConfigModificationError(
+            f"client_cpu_range {client_range!r} has only {pool_size} core(s), but "
+            f"a mixed load runs {MIXED_CONCURRENT_PROCESSES} concurrent processes "
+            f"needing {needed} ({cores_per_client} per process). Widen "
+            "client_cpu_range."
+        )
+
+    cpu_allocation = {
+        "cores_per_client": cores_per_client,
+        "clients": [client_range],
+    }
+    server_range = entry.get("server_cpu_range")
+    if server_range:
+        cpu_allocation["cores_per_server"] = len(parse_core_range(server_range))
+        cpu_allocation["servers"] = [server_range]
+    else:
+        cpu_allocation["cores_per_server"] = 1
+
+    entry["cpu_allocation"] = cpu_allocation
+    entry.pop("server_cpu_range", None)
+    entry.pop("client_cpu_range", None)
+
+
+def _build_mixed_group(
+    base: dict,
+    write_command: str,
+    read_command: str,
+    write_ratio: int,
+    pipelines: List[int],
+    data_sizes: List[int],
+) -> List[dict]:
+    """Build the ``test_groups`` block for a simultaneous read+write workload.
+
+    One ``type: "mixed"`` scenario per ``pipeline x data_size`` (id
+    ``mix_p{p}_d{d}``), each carrying the base's run bound (``duration`` OR
+    ``requests``), ``warmup``, and ``warmup_writes_only: True`` (only the write
+    side seeds the keyspace during warmup). The write/read ``clients`` split
+    comes from base ``clients[0]`` and ``write_ratio`` and sums to it exactly;
+    both are set explicitly because the framework does not inherit ``clients``
+    onto mixed sub-scenarios. Each side carries ``test:`` or ``command:`` per
+    ``_classify_mixed_workload``.
+    """
+    total_clients = base["clients"][0]
+    write_clients, read_clients = _split_clients(total_clients, write_ratio)
+
+    write_key, write_value = _classify_mixed_workload(write_command, side="write")
+    read_key, read_value = _classify_mixed_workload(read_command, side="read")
+    run_bound = _run_bound(base)
+
+    scenarios = []
+    for scenario_id, pipeline, data_size in _iter_sweep("mix", pipelines, data_sizes):
+        scenarios.append(
+            {
+                "id": scenario_id,
+                "type": "mixed",
+                "pipeline": pipeline,
+                "data_size": data_size,
+                "warmup": base.get("warmup", 0),
+                "warmup_writes_only": True,
+                # One process per sub-scenario PER active port: without this a
+                # multi-node cluster would double the process/client/CPU count.
+                # The script cannot know the node count, so it forces single.
+                "cluster_execution": "single",
+                **run_bound,
+                "writes": [
+                    {"id": "w", write_key: write_value, "clients": write_clients}
+                ],
+                "reads": [{"id": "r", read_key: read_value, "clients": read_clients}],
+            }
+        )
+    return [{"group": 1, "description": "mixed read+write", "scenarios": scenarios}]
+
+
+# ---------- Config building --------------------------------------------------
+
+
+def build_config(
+    base_configs: List[dict],
+    *,
+    commands: str = "",
+    arbitrary_command: str = "",
+    populate_command: str = "",
+    write_command: str = "",
+    read_command: str = "",
+    write_ratio: int = 50,
+    data_size: str = "",
+    io_threads: str = "",
+    benchmark_threads: str = "",
+    pipelines: str = "",
+    cluster_mode: Optional[bool] = None,
+    server_cpu_ceiling: int = DEFAULT_SERVER_CPU_CEILING,
+    max_io_threads: int = DEFAULT_MAX_IO_THREADS,
+    max_benchmark_threads: int = DEFAULT_MAX_BENCHMARK_THREADS,
+    max_sweep_scenarios: int = DEFAULT_MAX_SWEEP_SCENARIOS,
+) -> List[dict]:
+    """Return a modified copy of ``base_configs`` with overrides applied.
+
+    Parameters mirror the workflow input names and accept the same string forms
+    (an empty string means "leave the base config value untouched").
+    ``cluster_mode`` is tri-state: ``True`` enables, ``False`` disables, ``None``
+    leaves the base alone. Only the first config entry is modified.
+
+    Supplying ``arbitrary_command`` (or a write+read pair) CONVERTS entry [0] to
+    scenario format: its ``commands``/``data_sizes``/``pipelines`` are removed
+    and replaced by a generated ``test_groups`` block. The predefined-only flags
+    are rejected against an already-scenario-format base; only
+    ``--cluster-mode``/``--io-threads``/``--benchmark-threads`` apply to it.
+
+    The result is validated through ``validate_config`` (plus static CPU-conflict
+    checks) before returning; a failure is raised as ``ConfigModificationError``.
+    """
+    _validate_base_shape(base_configs)
+
+    configs = copy.deepcopy(base_configs)
+    entry = configs[0]
+
+    # Reject a base that sets both duration and requests before conversion, so
+    # the arbitrary/mixed paths (which delete 'commands') cannot slip it past
+    # the framework's commands-only check.
+    _validate_run_bound_exclusive(entry)
+
+    mixed_mode = bool(write_command or read_command)
+    if mixed_mode:
+        _validate_mixed_inputs(
+            write_command,
+            read_command,
+            write_ratio,
+            commands,
+            arbitrary_command,
+            populate_command,
+            entry,
+        )
+
+    # --commands and --arbitrary-command are mutually exclusive: arbitrary mode
+    # would otherwise silently win and discard --commands.
+    if commands and arbitrary_command:
+        raise ConfigModificationError(
+            "--commands cannot be combined with --arbitrary-command; arbitrary "
+            "mode replaces the predefined commands entirely. Supply only one."
+        )
+
+    # A scenario-format base has no commands/data_sizes/pipelines to edit or
+    # replace, so predefined-only flags cannot affect what runs.
+    if _is_scenario_format(entry):
+        offending = [
+            flag
+            for flag, supplied in (
+                ("--commands", commands),
+                ("--data-size", data_size),
+                ("--pipelines", pipelines),
+                ("--arbitrary-command", arbitrary_command),
+                ("--populate-command", populate_command),
+                ("--write-command", write_command),
+                ("--read-command", read_command),
+            )
+            if supplied
+        ]
+        if offending:
+            raise ConfigModificationError(
+                "base config entry [0] is already in scenario (test_groups) "
+                f"format; {', '.join(offending)} cannot be applied to it. Only "
+                f"{', '.join(UNIVERSAL_FLAGS)} apply to a scenario-format base."
+            )
+
+    # Parse and bounds-check the shared numeric inputs up front.
+    data_sizes = _parse_int_list(data_size, "data_size", DATA_SIZE_MIN, DATA_SIZE_MAX)
+    io_thread_list = _parse_int_list(io_threads, "io_threads", 1, max_io_threads)
+    pipeline_list = _parse_int_list(pipelines, "pipelines", PIPELINE_MIN, PIPELINE_MAX)
+    benchmark_thread_count = _parse_benchmark_threads(
+        benchmark_threads, max_benchmark_threads
+    )
+
+    if arbitrary_command:
+        _validate_command_string(arbitrary_command, "arbitrary_command")
+    if populate_command:
+        if not arbitrary_command:
+            raise ConfigModificationError(
+                "populate_command requires arbitrary_command."
+            )
+        _validate_command_string(populate_command, "populate_command")
+
+    def _apply_shared_overrides() -> None:
+        """Apply overrides valid in both modes (cluster, io-threads, threads)."""
+        if cluster_mode is not None:
+            entry["cluster_mode"] = cluster_mode
+        if io_thread_list is not None:
+            entry["io-threads"] = io_thread_list
+            entry["server_cpu_range"] = _derive_server_cpu_range(
+                io_thread_list, server_cpu_ceiling
+            )
+        if benchmark_thread_count is not None:
+            entry["benchmark-threads"] = benchmark_thread_count
+
+    if mixed_mode:
+        scenario_pipelines, scenario_sizes = _resolve_sweep(
+            entry, pipeline_list, data_sizes, max_sweep_scenarios
+        )
+        entry["test_groups"] = _build_mixed_group(
+            entry,
+            write_command,
+            read_command,
+            write_ratio,
+            scenario_pipelines,
+            scenario_sizes,
+        )
+        # Shared overrides first (an --io-threads override may rewrite
+        # server_cpu_range), then fold the CPU ranges into a cpu_allocation.
+        _apply_shared_overrides()
+        _apply_mixed_cpu_allocation(entry)
+    elif arbitrary_command:
+        scenario_pipelines, scenario_sizes = _resolve_sweep(
+            entry, pipeline_list, data_sizes, max_sweep_scenarios
+        )
+        entry["test_groups"] = _build_arbitrary_group(
+            entry,
+            arbitrary_command,
+            populate_command,
+            scenario_pipelines,
+            scenario_sizes,
+        )
+        _apply_shared_overrides()
+    else:
+        parsed_commands = _parse_commands(commands)
+        if parsed_commands is not None:
+            entry["commands"] = parsed_commands
+        if data_sizes is not None:
+            entry["data_sizes"] = data_sizes
+        if pipeline_list is not None:
+            entry["pipelines"] = pipeline_list
+        _apply_shared_overrides()
+
+    # Final gate: never emit something the runner would reject. validate_config
+    # mutates its argument (bool coercion, test_groups compilation), so validate
+    # a copy and keep the emitted config exactly as built.
+    for index, cfg in enumerate(configs):
+        _validate_cpu_config(cfg, index)
+        try:
+            validate_config(copy.deepcopy(cfg))
+        except ValueError as exc:
+            raise ConfigModificationError(
+                f"generated config entry [{index}] failed framework validation: {exc}"
+            )
+
+    return configs
+
+
+# ---------- CLI --------------------------------------------------------------
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse command-line arguments. Flags mirror the workflow input names."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Modify a benchmark config from named parameters, replacing the "
+            "jq/bash config surgery in on-demand benchmark workflows."
+        ),
+        allow_abbrev=False,
+    )
+    parser.add_argument("--config", required=True, help="Path to the base config JSON.")
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Where to write the modified config (default: overwrite --config).",
+    )
+    parser.add_argument(
+        "--commands",
+        default="",
+        help="Comma-separated predefined commands to benchmark (e.g. SET,GET).",
+    )
+    parser.add_argument(
+        "--arbitrary-command",
+        default="",
+        help="Arbitrary command to benchmark. CONVERTS entry [0] to scenario "
+        "format: its commands/data_sizes/pipelines are removed and replaced by "
+        "a generated test_groups block (one scenario per pipeline x data_size). "
+        "Cannot be combined with --commands.",
+    )
+    parser.add_argument(
+        "--populate-command",
+        default="",
+        help="Write command attached to each generated read scenario as "
+        "populate_with so populate and read share one seed. Requires "
+        "--arbitrary-command.",
+    )
+    parser.add_argument(
+        "--write-command",
+        default="",
+        help="Write side of a simultaneous mixed load. Accepts EITHER a "
+        "predefined command name (e.g. SET -> run as '-t SET') OR an arbitrary "
+        "command string (e.g. 'SET key:__rand_int__ __data__' -> run after "
+        "'--'). Supplying BOTH --write-command and --read-command CONVERTS "
+        "entry [0] to scenario format: its commands/data_sizes/pipelines are "
+        "replaced by a generated 'mixed' scenario (per pipeline x data_size) "
+        "whose write and read sides run concurrently. A predefined write value "
+        "must be a WRITE command. Mutually exclusive with --commands/"
+        "--arbitrary-command/--populate-command.",
+    )
+    parser.add_argument(
+        "--read-command",
+        default="",
+        help="Read side of a simultaneous mixed load. Accepts EITHER a "
+        "predefined command name (e.g. GET -> run as '-t GET') OR an arbitrary "
+        "command string (e.g. 'GET key:__rand_int__' -> run after '--'). A "
+        "predefined read value must be a READ command. See --write-command; "
+        "both must be supplied together.",
+    )
+    parser.add_argument(
+        "--write-ratio",
+        type=int,
+        default=50,
+        help="Percent of client connections given to the write side of a mixed "
+        "load (1-99, default 50); the read side takes the rest. 0 or 100 is not "
+        "a mixed load — use --arbitrary-command instead.",
+    )
+    parser.add_argument(
+        "--data-size",
+        default="",
+        help=f"Comma-separated data sizes in bytes "
+        f"(range: {DATA_SIZE_MIN}-{DATA_SIZE_MAX}).",
+    )
+    parser.add_argument(
+        "--io-threads",
+        default="",
+        help="Comma-separated io-threads values (range: 1-<max-io-threads>).",
+    )
+    parser.add_argument(
+        "--benchmark-threads",
+        default="",
+        help="Client thread count for valkey-benchmark "
+        "(range: 1-<max-benchmark-threads>).",
+    )
+    parser.add_argument(
+        "--pipelines",
+        default="",
+        help=f"Comma-separated pipeline values (range: {PIPELINE_MIN}-{PIPELINE_MAX}).",
+    )
+    parser.add_argument(
+        "--cluster-mode",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Tri-state: --cluster-mode enables, --no-cluster-mode disables, "
+        "omitted leaves the base config value unchanged.",
+    )
+    parser.add_argument(
+        "--server-cpu-ceiling",
+        type=int,
+        default=DEFAULT_SERVER_CPU_CEILING,
+        help="Max index for the derived server_cpu_range (runner-specific, "
+        f"default: {DEFAULT_SERVER_CPU_CEILING}).",
+    )
+    parser.add_argument(
+        "--max-io-threads",
+        type=int,
+        default=DEFAULT_MAX_IO_THREADS,
+        help="Upper bound for io-threads values (server NUMA-node CPUs, "
+        f"default: {DEFAULT_MAX_IO_THREADS}).",
+    )
+    parser.add_argument(
+        "--max-benchmark-threads",
+        type=int,
+        default=DEFAULT_MAX_BENCHMARK_THREADS,
+        help="Upper bound for benchmark-threads (client CPU pool size, "
+        f"default: {DEFAULT_MAX_BENCHMARK_THREADS}).",
+    )
+    parser.add_argument(
+        "--max-sweep-scenarios",
+        type=int,
+        default=DEFAULT_MAX_SWEEP_SCENARIOS,
+        help="Ceiling on generated pipelines x data_sizes scenarios "
+        f"(default: {DEFAULT_MAX_SWEEP_SCENARIOS}).",
+    )
+    parser.add_argument(
+        "--print",
+        dest="print_config",
+        action="store_true",
+        help="Print the resulting config to stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """CLI entry point. Returns a non-zero exit code on any validation error."""
+    args = parse_args(argv)
+
+    config_path = Path(args.config)
+    try:
+        with open(config_path, "r") as fp:
+            base_configs = json.load(fp)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Error: could not read config {config_path}: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        result = build_config(
+            base_configs,
+            commands=args.commands,
+            arbitrary_command=args.arbitrary_command,
+            populate_command=args.populate_command,
+            write_command=args.write_command,
+            read_command=args.read_command,
+            write_ratio=args.write_ratio,
+            data_size=args.data_size,
+            io_threads=args.io_threads,
+            benchmark_threads=args.benchmark_threads,
+            pipelines=args.pipelines,
+            cluster_mode=args.cluster_mode,
+            server_cpu_ceiling=args.server_cpu_ceiling,
+            max_io_threads=args.max_io_threads,
+            max_benchmark_threads=args.max_benchmark_threads,
+            max_sweep_scenarios=args.max_sweep_scenarios,
+        )
+    except ConfigModificationError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    # Make the mode explicit so a user is not surprised that the predefined
+    # fields vanished when an arbitrary command converts the entry.
+    if args.write_command or args.read_command:
+        print(
+            "Mode: mixed — entry [0] converted to scenario (test_groups) format; "
+            "its commands/data_sizes/pipelines were replaced by a generated "
+            "'mixed' scenario whose write and read sides run concurrently.",
+            file=sys.stderr,
+        )
+    elif args.arbitrary_command:
+        print(
+            "Mode: arbitrary-command — entry [0] converted to scenario "
+            "(test_groups) format; its commands/data_sizes/pipelines were "
+            "replaced by generated scenarios.",
+            file=sys.stderr,
+        )
+    else:
+        print("Mode: predefined — overrides applied in place.", file=sys.stderr)
+
+    output_path = Path(args.output) if args.output else config_path
+    try:
+        with open(output_path, "w") as fp:
+            json.dump(result, fp, indent=2)
+            fp.write("\n")
+    except OSError as exc:
+        print(
+            f"Error: could not write output config {output_path}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.print_config:
+        print(json.dumps(result, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -8,7 +8,6 @@ import subprocess
 import time
 import csv
 from contextlib import contextmanager
-from itertools import product
 from pathlib import Path
 from typing import Iterable, List, Optional
 
@@ -18,6 +17,7 @@ from process_metrics import MetricsProcessor
 from valkey_server import ServerLauncher, apply_config_to_servers
 from profiler import PerformanceProfiler
 from utils.git_utils import resolve_ref, get_commit_timestamp
+from utils.cpu_utils import format_core_list, parse_core_range
 from environment_metadata import collect_environment_metadata
 
 # Constants
@@ -53,6 +53,10 @@ READ_POPULATE_MAP = {
     "ZRANGE": "ZADD",
 }
 
+# Compiled basic scenarios retain the basic metrics schema and shared seed.
+ORIGIN_FIELD = "_origin"
+ORIGIN_SIMPLE = "simple"
+
 
 def deep_merge(base: dict, override: dict) -> dict:
     """Deep merge override into base, returning new dict."""
@@ -84,7 +88,6 @@ class ClientRunner:
         runs: int = 1,
         server_launcher: Optional[ServerLauncher] = None,
         architecture: Optional[str] = None,
-        uses_test_groups: bool = False,
         repository: Optional[str] = None,
         config_name: Optional[str] = None,
         module_commit: Optional[str] = None,
@@ -104,7 +107,6 @@ class ClientRunner:
         self.runs = runs
         self.server_launcher = server_launcher
         self.architecture = architecture
-        self.uses_test_groups = uses_test_groups
         self.repository = repository
         self.config_name = config_name
         self.module_commit = module_commit
@@ -294,7 +296,8 @@ class ClientRunner:
 
     def _populate_keyspace(
         self,
-        read_command: str,
+        workload_key: str,
+        write_workload: str,
         requests: int,
         keyspacelen: int,
         data_size: int,
@@ -302,126 +305,63 @@ class ClientRunner:
         clients: int,
         seed_val: int,
     ) -> None:
-        """Populate keyspace for a read command using its write equivalent."""
-        write_cmd = READ_POPULATE_MAP.get(read_command)
-        if not write_cmd:
-            logging.info(f"No populate needed for {read_command}")
-            return
+        """Run a sequential write workload to seed the keyspace."""
+        logging.info(f"Populating keyspace using {write_workload}")
 
-        logging.info(f"Populating keyspace for {read_command} using {write_cmd}")
-
+        populate_scenario = {
+            workload_key: write_workload,
+            "requests": requests,
+            "keyspacelen": keyspacelen,
+            "data_size": data_size,
+            "pipeline": pipeline,
+            "clients": clients,
+            "sequential": True,
+        }
         bench_cmd = self._build_benchmark_command(
-            tls=self.tls_mode,
-            requests=requests,
-            keyspacelen=keyspacelen,
-            data_size=data_size,
-            pipeline=pipeline,
-            clients=clients,
-            command=write_cmd,
-            seed_val=seed_val,
-            sequential=True,
+            populate_scenario, tls=self.tls_mode, seed_val=seed_val
         )
 
         self._run(command=bench_cmd, cwd=self.valkey_path, timeout=None)
-        logging.info(f"Keyspace populated for {read_command} with {requests} keys")
+        logging.info(f"Keyspace populated using {write_workload} with {requests} keys")
 
     def run_benchmark_config(self) -> None:
-        """Orchestrate benchmark execution for both config formats."""
+        """Execute the configured scenarios and persist their metrics."""
         commit_time = self.get_commit_time(self.commit_id)
 
-        # Setup profiling/metrics infrastructure
         (
             profiler,
             metrics_processor,
             profiling_enabled,
         ) = self._setup_profiling_and_metrics(self.current_profiling_set, commit_time)
 
-        # Execute all scenarios and collect results
         metric_json = []
-        for scenario_data in self._iterate_scenarios():
-            result = self._execute_scenario(
-                scenario_data,
+        for scenario_data in self._iterate_test_groups_scenarios():
+            result = self._run_single_scenario(
+                scenario_data["scenario"],
+                scenario_data["group_id"],
                 profiler,
                 metrics_processor,
-                profiling_enabled,
-                commit_time,
+                scenario_data["config_set"],
+                scenario_data["config_suffix"],
+                scenario_data.get("group_description"),
             )
             if result:
-                # Mixed workloads return a list of metrics (one per sub-scenario)
                 if isinstance(result, list):
                     metric_json.extend(result)
                 else:
                     metric_json.append(result)
 
-        # Finalize and write results
         self._finalize_metrics(metrics_processor, metric_json, profiling_enabled)
 
     def _get_effective_runs(self) -> int:
-        """Return the number of runs to execute.
-
-        When profiling is enabled we only run once.
-        """
+        """Return one run while profiling, otherwise the configured count."""
         if self.current_profiling_set.get("enabled", False) and self.runs > 1:
             logging.info("Profiling enabled: forcing runs=1 (profiling runs only once)")
             return 1
         return self.runs
 
-    def _iterate_scenarios(self):
-        """Generate scenario execution data from either config format."""
-        if self.uses_test_groups:
-            yield from self._iterate_test_groups_scenarios()
-        else:
-            yield from self._iterate_simple_scenarios()
-
-    def _iterate_simple_scenarios(self):
-        """Generate scenarios from simple command-based configuration."""
-        for (
-            requests,
-            keyspacelen,
-            data_size,
-            pipeline,
-            clients,
-            command,
-            warmup,
-            duration,
-        ) in self._generate_combinations():
-            # Validate command
-            if command not in READ_COMMANDS + WRITE_COMMANDS:
-                logging.warning(f"Unsupported command: {command}, skipping.")
-                continue
-
-            if command in ["MSET", "MGET"] and self.cluster_mode:
-                logging.warning(
-                    f"Command {command} not supported in cluster mode, skipping."
-                )
-                continue
-
-            # Run multiple times if requested (profiling forces a single run)
-            for run_num in range(self._get_effective_runs()):
-                seed_val = random.randint(0, 1000000)
-
-                yield {
-                    "format": "simple",
-                    "run_num": run_num,
-                    "requests": requests,
-                    "keyspacelen": keyspacelen,
-                    "data_size": data_size,
-                    "pipeline": pipeline,
-                    "clients": clients,
-                    "command": command,
-                    "warmup": warmup,
-                    "duration": duration,
-                    "seed": seed_val,
-                    "needs_population": command in READ_COMMANDS,
-                    "populate_command": READ_POPULATE_MAP.get(command),
-                }
-
     def _iterate_test_groups_scenarios(self):
-        """Generate scenarios from test_groups configuration.
-
-        When ``self.runs > 1``, the entire group is repeated multiple times.
-        Profiling mode forces a single run (see ``_get_effective_runs``).
-        """
+        """Yield scenarios in group/run/scenario order."""
         effective_runs = self._get_effective_runs()
         groups_to_run = self.config.get("groups_to_run")
         scenario_filter = self.config.get("scenario_filter")
@@ -430,7 +370,6 @@ class ClientRunner:
             group_id = test_group.get("group", "unknown")
             group_description = test_group.get("description")
 
-            # Skip filtered groups
             if groups_to_run and group_id not in groups_to_run:
                 logging.info(
                     f"Skipping group {group_id} (not in filter: {groups_to_run})"
@@ -447,9 +386,15 @@ class ClientRunner:
                     logging.info(f"=== Group {group_id}: {group_description or ''} ===")
 
                 for scenario in test_group.get("scenarios", []):
-                    # Expand scenario options (e.g., with/without flags)
+                    # Cluster mode is scalarized only at execution time.
+                    test_cmd = scenario.get("test")
+                    if test_cmd in ("MSET", "MGET") and self.cluster_mode:
+                        logging.warning(
+                            f"Command {test_cmd} not supported in cluster mode, skipping."
+                        )
+                        continue
+
                     for expanded_scenario in self._expand_scenario_options(scenario):
-                        # Skip filtered scenarios
                         if (
                             scenario_filter
                             and expanded_scenario.get("id") not in scenario_filter
@@ -460,7 +405,6 @@ class ClientRunner:
                             continue
 
                         yield {
-                            "format": "test_groups",
                             "scenario": expanded_scenario,
                             "group_id": group_id,
                             "group_description": group_description,
@@ -468,188 +412,29 @@ class ClientRunner:
                             "config_suffix": self.config_suffix,
                         }
 
-    def _execute_scenario(
-        self, scenario_data, profiler, metrics_processor, profiling_enabled, commit_time
-    ):
-        """Execute a single scenario regardless of format."""
-        if scenario_data["format"] == "simple":
-            return self._execute_simple_scenario(scenario_data, metrics_processor)
-        else:
-            return self._execute_test_groups_scenario(
-                scenario_data,
-                profiler,
-                metrics_processor,
-                profiling_enabled,
-                commit_time,
-            )
-
-    def _execute_simple_scenario(self, data, metrics_processor):
-        """Execute a simple format scenario."""
-        if self.runs > 1:
-            logging.info(f"=== Run {data['run_num'] + 1}/{self.runs} ===")
-
-        mode_info = (
-            f"duration={data['duration']}s"
-            if data["duration"] is not None
-            else f"requests={data['requests']}"
-        )
-        logging.info(
-            f"--> Running {data['command']} | size={data['data_size']} | "
-            f"pipeline={data['pipeline']} | clients={data['clients']} | {mode_info} | "
-            f"keyspacelen={data['keyspacelen']} | warmup={data['warmup']}"
-        )
-        logging.info(f"Using seed value: {data['seed']}")
-
-        # Restart/flush
-        if self.server_launcher:
-            self._restart_server()
-        else:
-            self._flush_database()
-
-        # Populate if needed
-        if data["needs_population"]:
-            populate_requests = (
-                data["requests"]
-                if data["requests"] is not None
-                else data["keyspacelen"]
-            )
-            self._populate_keyspace(
-                data["command"],
-                populate_requests,
-                data["keyspacelen"],
-                data["data_size"],
-                data["pipeline"],
-                data["clients"],
-                data["seed"],
-            )
-
-        # Run benchmark
-        bench_cmd = self._build_benchmark_command(
-            tls=self.tls_mode,
-            requests=data["requests"],
-            keyspacelen=data["keyspacelen"],
-            data_size=data["data_size"],
-            pipeline=data["pipeline"],
-            clients=data["clients"],
-            command=data["command"],
-            seed_val=data["seed"],
-            sequential=False,
-            duration=data["duration"],
-            warmup=data["warmup"],
-        )
-
-        proc = self._run(
-            bench_cmd, cwd=self.valkey_path, capture_output=True, timeout=None
-        )
-        if proc is None:
-            logging.error("Benchmark command failed to return results")
-            return None
-
-        logging.info(f"Benchmark output:\n{proc.stdout}")
-        if proc.stderr:
-            logging.warning(f"Benchmark stderr:\n{proc.stderr}")
-
-        # Parse metrics
-        try:
-            reader = csv.DictReader(proc.stdout.splitlines())
-            for row in reader:
-                test_name = row.get("test", "")
-                if not test_name.startswith(data["command"]):
-                    continue
-
-                metrics = metrics_processor.create_metrics(
-                    row,
-                    test_name,
-                    data["data_size"],
-                    data["pipeline"],
-                    data["clients"],
-                    data["requests"],
-                    data["warmup"],
-                    data["duration"],
-                )
-                if metrics:
-                    logging.info(f"Parsed metrics for {test_name}: {metrics}")
-                    return metrics
-        except Exception as e:
-            logging.error(f"Failed to parse benchmark results: {e}")
-
-        return None
-
-    def _execute_test_groups_scenario(
-        self, data, profiler, metrics_processor, profiling_enabled, commit_time
-    ):
-        """Execute a test_groups format scenario."""
-        return self._run_single_scenario(
-            data["scenario"],
-            data["group_id"],
-            profiler,
-            metrics_processor,
-            profiling_enabled,
-            commit_time,
-            data["config_set"],
-            data["config_suffix"],
-            data.get("group_description"),
-        )
-
-    def _generate_combinations(self) -> List[tuple]:
-        """Cartesian product of parameters within a single config item."""
-        # Use requests if available, otherwise None for duration mode
-        requests_list = self.config.get("requests", [None])
-
-        return list(
-            product(
-                requests_list,
-                self.config["keyspacelen"],
-                self.config["data_sizes"],
-                self.config["pipelines"],
-                self.config["clients"],
-                self.config["commands"],
-                [self.config["warmup"]],
-                [self.config.get("duration")],
-            )
-        )
-
     def _build_benchmark_command(
         self,
-        tls: Optional[bool] = None,
-        requests: Optional[int] = None,
-        keyspacelen: Optional[int] = None,
-        data_size: Optional[int] = None,
-        pipeline: Optional[int] = None,
-        clients: Optional[int] = None,
-        command: Optional[str] = None,
-        seed_val: Optional[int] = None,
+        scenario: dict,
         *,
-        sequential: bool = False,
-        duration: Optional[int] = None,
-        warmup: Optional[int] = None,
-        scenario: Optional[dict] = None,
+        tls: Optional[bool] = None,
+        seed_val: Optional[int] = None,
         warmup_mode: bool = False,
         port: Optional[int] = None,
         cpu_range: Optional[str] = None,
     ) -> List[str]:
-        """Unified command builder for both simple and test_groups formats.
+        """Build argv for a predefined ``test`` or arbitrary ``command``.
 
-        Usage:
-            # Simple format (positional args)
-            _build_benchmark_command(tls=True, requests=1000, keyspacelen=1000, ...)
-
-            # Test groups format (scenario dict)
-            _build_benchmark_command(scenario={"command": "FT.SEARCH ...", ...})
+        ``seed_val`` shares a seed across related invocations; when omitted,
+        each invocation draws one unless seeding is disabled.
         """
         cmd = []
 
-        # Determine format
-        is_test_groups = scenario is not None
-
-        # CPU pinning
         cores = cpu_range or self.cores
         if cores:
             cmd += ["taskset", "-c", cores]
 
         cmd.append(self.valkey_benchmark_path)
 
-        # TLS configuration
         use_tls = tls if tls is not None else self.tls_mode
         if use_tls:
             cmd += ["--tls"]
@@ -657,12 +442,41 @@ class ClientRunner:
             cmd += ["--key", "./tests/tls/valkey.key"]
             cmd += ["--cacert", "./tests/tls/ca.crt"]
 
-        # Connection settings
         cmd += ["-h", self.target_ip]
         cmd += ["-p", str(port or self.config.get("port", DEFAULT_PORT))]
 
-        if is_test_groups:
-            # Test groups format: extract from scenario
+        keyspacelen_val = scenario.get(
+            "keyspacelen", self.config.get("keyspacelen", [1000000])[0]
+        )
+
+        if "test" in scenario:
+            if warmup_mode:
+                cmd += ["--duration", str(scenario.get("warmup", 60))]
+            elif scenario.get("duration") is not None:
+                cmd += ["--duration", str(scenario["duration"])]
+            elif scenario.get("requests") is not None:
+                cmd += ["-n", str(scenario["requests"])]
+            else:
+                raise ValueError(
+                    f"test scenario {scenario.get('id')!r} requires "
+                    "'requests' or 'duration'"
+                )
+
+            cmd += ["-r", str(keyspacelen_val)]
+            if scenario.get("data_size") is not None:
+                cmd += ["-d", str(scenario["data_size"])]
+            cmd += ["-P", str(scenario.get("pipeline", 1))]
+            cmd += ["-c", str(scenario.get("clients", 1))]
+            cmd += ["-t", scenario["test"]]
+
+            if self.benchmark_threads is not None:
+                cmd += ["--threads", str(self.benchmark_threads)]
+
+            # Inline warmup is distinct from the scenario's pre-run warmup.
+            warmup_inline = scenario.get("warmup_inline")
+            if not warmup_mode and warmup_inline is not None and warmup_inline > 0:
+                cmd += ["--warmup", str(warmup_inline)]
+        else:
             if scenario.get("dataset"):
                 dataset_path = Path(scenario["dataset"])
                 if not dataset_path.is_absolute():
@@ -675,7 +489,6 @@ class ClientRunner:
                 if scenario.get("maxdocs") and scenario.get("type") == "write":
                     cmd += ["--maxdocs", str(scenario["maxdocs"])]
 
-            # Duration/requests
             if warmup_mode:
                 warmup_duration = scenario.get("warmup", 60)
                 cmd += ["--duration", str(warmup_duration)]
@@ -691,57 +504,28 @@ class ClientRunner:
 
             cmd += ["-c", str(scenario.get("clients", 1))]
             cmd += ["-P", str(scenario.get("pipeline", 1))]
-
-            keyspacelen_val = self.config.get("keyspacelen", [1000000])[0]
             cmd += ["-r", str(keyspacelen_val)]
-
-            if scenario.get("sequential", False):
-                cmd += ["--sequential"]
-
-            if self._should_add_cluster_flag(scenario):
-                cmd += ["--cluster"]
-
-            # Seed: Default ON unless explicitly disabled with "seed": false
-            if (
-                scenario.get("seed") is not False
-                and self.config.get("seed") is not False
-            ):
-                seed = seed_val if seed_val is not None else random.randint(0, 1000000)
-                cmd += ["--seed", str(seed)]
-
-            cmd += ["--csv"]
-            cmd += ["--"]
-            cmd += shlex.split(scenario["command"])
-        else:
-            # Simple format: use positional args
-            if duration is not None:
-                cmd += ["--duration", str(duration)]
-            else:
-                cmd += ["-n", str(requests)]
-
-            cmd += ["-r", str(keyspacelen)]
-            cmd += ["-d", str(data_size)]
-            cmd += ["-P", str(pipeline)]
-            cmd += ["-c", str(clients)]
-            cmd += ["-t", command]
+            if scenario.get("data_size") is not None:
+                cmd += ["-d", str(scenario["data_size"])]
 
             if self.benchmark_threads is not None:
                 cmd += ["--threads", str(self.benchmark_threads)]
 
-            if warmup is not None and warmup > 0:
-                cmd += ["--warmup", str(warmup)]
+        if scenario.get("sequential", False):
+            cmd += ["--sequential"]
 
-            if sequential:
-                cmd += ["--sequential"]
+        if self._should_add_cluster_flag(scenario):
+            cmd += ["--cluster"]
 
-            if self._should_add_cluster_flag():
-                cmd += ["--cluster"]
+        if scenario.get("seed") is not False and self.config.get("seed") is not False:
+            seed = seed_val if seed_val is not None else random.randint(0, 1000000)
+            cmd += ["--seed", str(seed)]
 
-            # Unified seed logic: Default ON unless config disables
-            if self.config.get("seed") is not False:
-                cmd += ["--seed", str(seed_val)]
+        cmd += ["--csv"]
 
-            cmd += ["--csv"]
+        if "command" in scenario:
+            cmd += ["--"]
+            cmd += shlex.split(scenario["command"])
 
         return cmd
 
@@ -765,6 +549,24 @@ class ClientRunner:
             return row
         return None
 
+    def _parse_csv_row_for_test(self, stdout: str, test_name: str) -> Optional[dict]:
+        """Parse CSV output of a predefined ``-t`` workload.
+
+        ``valkey-benchmark -t CMD`` emits rows whose test name may be a
+        variant of the command (e.g. ``MSET (10 keys)``), so the first row
+        whose test name starts with the benchmarked name is returned.
+        """
+        if not stdout:
+            return None
+        lines = stdout.splitlines()
+        csv_start = self._find_csv_start(lines)
+        if csv_start is None:
+            return None
+        for row in csv.DictReader(lines[csv_start:]):
+            if row.get("test", "").startswith(test_name):
+                return row
+        return None
+
     def _is_cme(self) -> bool:
         """Check if cluster mode is enabled with multiple nodes."""
         return self.cluster_mode and self.config.get("cluster_nodes", 1) > 1
@@ -776,27 +578,23 @@ class ClientRunner:
         )
 
     def _expand_scenario_options(self, scenario: dict) -> List[dict]:
-        """Expand scenario with options to create variants.
-
-        For mixed workloads, options are applied to all read sub-scenarios
-        rather than the top-level command.
-        """
+        """Expand option variants, applying mixed options to read children."""
         options = scenario.get("options")
 
-        # No options: return scenario as-is
         if not options:
             return [scenario]
 
-        # Options provided: create variant for each option
         scenarios = []
         for flag, suffix in options.items():
             variant = copy.deepcopy(scenario)
             variant["id"] = scenario["id"] + suffix
 
             if variant.get("type") == "mixed":
-                # Mixed: apply option flag to each read sub-scenario
                 for read in variant.get("reads", []):
-                    if flag:
+                    # options append a benchmark flag to an arbitrary command
+                    # string; a predefined ``test:`` read has no command string
+                    # to extend, so leave it untouched.
+                    if flag and "command" in read:
                         read["command"] = read["command"] + f" {flag}"
             else:
                 variant["command"] = scenario["command"] + (f" {flag}" if flag else "")
@@ -807,28 +605,86 @@ class ClientRunner:
 
         return scenarios
 
+    def _apply_row_metadata(
+        self,
+        metrics: dict,
+        *,
+        test_id: str,
+        test_phase: str,
+        group_id,
+        scenario_id: str,
+        config_set: dict,
+        group_description: Optional[str] = None,
+        scenario_description: Optional[str] = None,
+        dataset: Optional[str] = None,
+    ) -> None:
+        """Stamp shared scenario identity fields onto ``metrics`` in place.
+
+        Optional fields remain absent when unset so success and failure rows
+        have identical comparison keys.
+        """
+        metrics["test_id"] = test_id
+        metrics["test_phase"] = test_phase
+        metrics["group"] = group_id
+        metrics["scenario"] = scenario_id
+        metrics["config_set"] = config_set
+        if group_description:
+            metrics["group_description"] = group_description
+        if scenario_description:
+            metrics["scenario_description"] = scenario_description
+        if self.config_name:
+            metrics["config_name"] = self.config_name
+        if self.module_commit:
+            metrics["module_commit"] = self.module_commit
+        if self.module_commit_timestamp:
+            metrics["module_commit_timestamp"] = self.module_commit_timestamp
+        if dataset:
+            metrics["dataset"] = dataset
+
     def _create_failure_marker(
         self,
-        group_id: int,
+        metrics_processor,
+        workload: dict,
+        *,
+        group_id,
         scenario_id: str,
-        scenario_type: str,
+        test_id: str,
+        test_phase: str,
         error: str,
-        command: str,
-        timestamp: str,
-        config_set: dict,
+        config_set: Optional[dict] = None,
+        requests: Optional[int] = None,
+        warmup: Optional[int] = None,
+        parent_scenario: Optional[dict] = None,
+        group_description: Optional[str] = None,
     ) -> dict:
-        """Create failure marker dict for failed scenarios."""
-        return {
-            "test_id": f"{group_id}_{scenario_id}",
-            "test_phase": scenario_type,
-            "group": group_id,
-            "scenario": scenario_id,
-            "status": "failed",
-            "error": error,
-            "command": command,
-            "timestamp": timestamp,
-            "config_set": config_set,
-        }
+        """Build a failed row with identity metadata but no performance fields.
+
+        Mixed children inherit duration and description from their parent.
+        """
+        parent = parent_scenario or workload
+        marker = metrics_processor.build_base_metadata(
+            workload.get("command") or workload.get("test", ""),
+            workload.get("data_size", 100),
+            workload.get("pipeline", 1),
+            workload.get("clients", 1),
+            requests=requests,
+            warmup=warmup,
+            duration=workload.get("duration") or parent.get("duration"),
+        )
+        marker["status"] = "failed"
+        marker["error"] = error
+        self._apply_row_metadata(
+            marker,
+            test_id=test_id,
+            test_phase=test_phase,
+            group_id=group_id,
+            scenario_id=scenario_id,
+            config_set=config_set if config_set is not None else {},
+            group_description=group_description,
+            scenario_description=parent.get("description"),
+            dataset=workload.get("dataset"),
+        )
+        return marker
 
     def _setup_profiling_and_metrics(self, profiling_set: dict, commit_time: str):
         """Setup profiler and metrics processor based on profiling_set."""
@@ -884,19 +740,129 @@ class ClientRunner:
         group_id,
         profiler,
         metrics_processor,
-        profiling_enabled,
-        commit_time,
         config_set,
         config_suffix,
         group_description=None,
     ):
-        """Run a single scenario."""
+        """Run one scenario and return its metric row(s)."""
         scenario_type = scenario.get("type", "test")
         scenario_id = scenario.get("id", "unknown")
+        origin_simple = scenario.get(ORIGIN_FIELD) == ORIGIN_SIMPLE
 
         logging.info(f"Running scenario: {scenario_id} (type: {scenario_type})")
 
-        if scenario.get("flush_before", False):
+        self._prepare_server_state(scenario, config_set)
+
+        seed_val = self._draw_scenario_seed(scenario, origin_simple)
+
+        effective_profiling = self._resolve_effective_profiling(scenario)
+        scenario_profiling_enabled = effective_profiling.get("enabled", False)
+        profile_id = f"group{group_id}_{scenario_type}_{scenario_id}_{config_suffix}"
+
+        warmup_duration = scenario.get("warmup", 0)
+        try:
+            # Population failures follow the scenario's normal error policy.
+            self._populate_scenario_keyspace(scenario, seed_val)
+
+            self._run_scenario_warmup(scenario, group_id, config_set)
+
+            self._start_scenario_profiling(
+                profiler, scenario_profiling_enabled, effective_profiling, profile_id
+            )
+
+            # This finally is the single profiling teardown path.
+            try:
+                if scenario_type == "mixed":
+                    logging.info(f"Running mixed workload for scenario {scenario_id}")
+                    metrics_list = self._run_mixed_workload(
+                        scenario,
+                        group_id,
+                        config_set,
+                        metrics_processor,
+                        warmup_duration,
+                        group_description=group_description,
+                    )
+                    return metrics_list if metrics_list else None
+
+                # Invocation errors reach the outer scenario error policy.
+                proc, aggregated_row = self._execute_benchmark_run(scenario, seed_val)
+
+                if proc is None and aggregated_row is None:
+                    logging.error(f"Benchmark failed for scenario {scenario_id}")
+                    # Basic metrics omit scenario-schema failure markers.
+                    if metrics_processor and not origin_simple:
+                        return self._create_failure_marker(
+                            metrics_processor,
+                            scenario,
+                            group_id=group_id,
+                            scenario_id=scenario_id,
+                            test_id=f"{group_id}_{scenario_id}",
+                            test_phase=scenario_type,
+                            error="No results",
+                            config_set=config_set,
+                            requests=scenario.get("requests")
+                            or scenario.get("maxdocs"),
+                            warmup=scenario.get("warmup_inline", warmup_duration),
+                            group_description=group_description,
+                        )
+                    return None
+
+                if proc:
+                    logging.info(f"Benchmark output:\n{proc.stdout}")
+
+                # Basic parse failures skip one combination; other scenarios
+                # emit a failure marker through the outer handler.
+                try:
+                    return self._build_scenario_metrics(
+                        scenario,
+                        proc,
+                        aggregated_row,
+                        group_id,
+                        config_set,
+                        warmup_duration,
+                        group_description,
+                        metrics_processor,
+                    )
+                except Exception as e:
+                    if origin_simple:
+                        logging.error(
+                            f"Failed to parse benchmark results for scenario "
+                            f"{group_id}_{scenario_id}: {e}"
+                        )
+                        return None
+                    raise
+            finally:
+                self._stop_scenario_profiling(
+                    profiler, scenario_profiling_enabled, profile_id
+                )
+
+        except Exception as e:
+            if origin_simple:
+                raise
+            logging.error(f"Scenario {group_id}_{scenario_id} failed: {e}")
+            if metrics_processor:
+                return self._create_failure_marker(
+                    metrics_processor,
+                    scenario,
+                    group_id=group_id,
+                    scenario_id=scenario_id,
+                    test_id=f"{group_id}_{scenario_id}",
+                    test_phase=scenario_type,
+                    error=str(e),
+                    config_set=config_set,
+                    requests=scenario.get("requests") or scenario.get("maxdocs"),
+                    warmup=scenario.get("warmup_inline", warmup_duration),
+                    group_description=group_description,
+                )
+
+        return None
+
+    def _prepare_server_state(self, scenario, config_set):
+        """Clean server state before a scenario runs, then run setup commands.
+
+        Restart when a launcher is available; otherwise flush the database.
+        """
+        if scenario.get("restart_before", False) or scenario.get("flush_before", False):
             if self.server_launcher:
                 self._restart_server()
                 # Re-apply config_set after restart since CONFIG SET values are lost
@@ -908,177 +874,224 @@ class ClientRunner:
         for setup_cmd in scenario.get("setup_commands", []):
             self._execute_setup_command(setup_cmd)
 
+    def _draw_scenario_seed(self, scenario, origin_simple):
+        """Draw one seed shared by a populate pass and its main run."""
+        if origin_simple or scenario.get("populate_with"):
+            seed_val = random.randint(0, 1000000)
+            logging.info(f"Using seed value: {seed_val}")
+            return seed_val
+        return None
+
+    def _populate_scenario_keyspace(self, scenario, seed_val):
+        """Seed a scenario's keyspace through its configured write workload."""
+        populate_with = scenario.get("populate_with")
+        if not populate_with:
+            return
+
+        keyspacelen_val = scenario.get(
+            "keyspacelen", self.config.get("keyspacelen", [1000000])[0]
+        )
+        populate_requests = (
+            scenario["requests"]
+            if scenario.get("requests") is not None
+            else keyspacelen_val
+        )
+        workload_key = "command" if "command" in scenario else "test"
+        self._populate_keyspace(
+            workload_key,
+            populate_with,
+            populate_requests,
+            keyspacelen_val,
+            scenario.get("data_size", 100),
+            scenario.get("pipeline", 1),
+            scenario.get("clients", 1),
+            seed_val,
+        )
+
+    def _resolve_effective_profiling(self, scenario):
+        """Merge a scenario's profiling override onto the current profiling set."""
         if scenario.get("profiling"):
-            effective_profiling = deep_merge(
-                self.current_profiling_set, scenario["profiling"]
+            return deep_merge(self.current_profiling_set, scenario["profiling"])
+        return self.current_profiling_set
+
+    def _run_scenario_warmup(self, scenario, group_id, config_set):
+        """Run the scenario-shaped warmup pass and discard its results."""
+        warmup_duration = scenario.get("warmup", 0)
+        if warmup_duration <= 0:
+            return
+
+        scenario_type = scenario.get("type", "test")
+        if scenario_type == "mixed":
+            warmup_scenario = copy.deepcopy(scenario)
+            warmup_scenario["duration"] = warmup_duration
+            # Opt-in: warm only the write side. Reads during warmup query a cold
+            # keyspace, are discarded anyway, and consume client capacity that
+            # could be populating. Absent/false keeps today's full mixed warmup
+            # exactly, so configs relying on it to warm read-path state (e.g. the
+            # FTS scenario "j") are unaffected.
+            if warmup_scenario.get("warmup_writes_only"):
+                warmup_scenario["reads"] = []
+                logging.info(f"Running mixed warmup (writes only): {warmup_duration}s")
+            else:
+                logging.info(f"Running mixed warmup: {warmup_duration}s")
+            self._run_mixed_workload(
+                warmup_scenario,
+                group_id,
+                config_set,
+                metrics_processor=None,
+                warmup_duration=0,
+            )
+        elif self._should_use_parallel(scenario):
+            logging.info(
+                f"Running parallel warmup on {len(self._get_active_ports())} nodes: {warmup_duration}s"
+            )
+            self._run_parallel_search(
+                scenario,
+                self._get_active_ports(),
+                self.client_cpu_ranges,
+                warmup_mode=True,
             )
         else:
-            effective_profiling = self.current_profiling_set
+            logging.info(f"Running warmup: {warmup_duration}s")
+            cpu = self.client_cpu_ranges[0] if self.client_cpu_ranges else None
+            self._run(
+                self._build_benchmark_command(
+                    scenario=scenario, warmup_mode=True, cpu_range=cpu
+                ),
+                cwd=self.valkey_path,
+                capture_output=True,
+                timeout=None,
+            )
 
-        scenario_profiling_enabled = effective_profiling.get("enabled", False)
-        profile_id = f"group{group_id}_{scenario_type}_{scenario_id}_{config_suffix}"
+    def _start_scenario_profiling(
+        self, profiler, scenario_profiling_enabled, effective_profiling, profile_id
+    ):
+        """Start profiling for a scenario when a profiler is enabled."""
+        if profiler and scenario_profiling_enabled:
+            target_port = self._get_active_ports()[0] if self._is_cme() else None
+            if target_port:
+                logging.info(f"CME profiling: targeting node 0 on port {target_port}")
 
-        warmup_duration = scenario.get("warmup", 0)
-        try:
-            if warmup_duration > 0:
-                if scenario_type == "mixed":
-                    logging.info(f"Running mixed warmup: {warmup_duration}s")
-                    warmup_scenario = copy.deepcopy(scenario)
-                    warmup_scenario["duration"] = warmup_duration
-                    # Run mixed workload for warmup, discard results
-                    self._run_mixed_workload(
-                        warmup_scenario,
-                        group_id,
-                        config_set,
-                        metrics_processor=None,
-                        warmup_duration=0,
-                        commit_time=commit_time,
-                    )
-                elif self._should_use_parallel(scenario):
-                    logging.info(
-                        f"Running parallel warmup on {len(self._get_active_ports())} nodes: {warmup_duration}s"
-                    )
-                    # Warm up all nodes that will be queried
-                    self._run_parallel_search(
-                        scenario,
-                        self._get_active_ports(),
-                        self.client_cpu_ranges,
-                        warmup_mode=True,
-                    )
-                else:
-                    logging.info(f"Running warmup: {warmup_duration}s")
-                    cpu = self.client_cpu_ranges[0] if self.client_cpu_ranges else None
-                    self._run(
-                        self._build_benchmark_command(
-                            scenario=scenario, warmup_mode=True, cpu_range=cpu
-                        ),
-                        cwd=self.valkey_path,
-                        capture_output=True,
-                        timeout=None,
-                    )
+            # Pass scenario delays override
+            profiler.delays = effective_profiling.get("delays", profiler.delays)
+            profiler.start_profiling(
+                profile_id, target_process="valkey-server", target_port=target_port
+            )
 
-            if profiler and scenario_profiling_enabled:
-                target_port = self._get_active_ports()[0] if self._is_cme() else None
-                if target_port:
-                    logging.info(
-                        f"CME profiling: targeting node 0 on port {target_port}"
-                    )
+    def _stop_scenario_profiling(
+        self, profiler, scenario_profiling_enabled, profile_id
+    ):
+        """Stop profiling for a scenario when a profiler is enabled."""
+        if profiler and scenario_profiling_enabled:
+            profiler.stop_profiling(profile_id)
 
-                # Pass scenario delays override
-                profiler.delays = effective_profiling.get("delays", profiler.delays)
-                profiler.start_profiling(
-                    profile_id, target_process="valkey-server", target_port=target_port
-                )
+    def _execute_benchmark_run(self, scenario, seed_val):
+        """Return a process or an aggregated row for a non-mixed scenario."""
+        if self._should_use_parallel(scenario):
+            logging.info(
+                f"Using parallel execution for scenario {scenario.get('id', 'unknown')}"
+            )
+            aggregated_row = self._run_parallel_search(
+                scenario,
+                self._get_active_ports(),
+                self.client_cpu_ranges,
+                seed_val=seed_val,
+            )
+            return None, aggregated_row
 
-            # Handle mixed workload: run concurrent writes + reads
-            if scenario_type == "mixed":
-                logging.info(f"Running mixed workload for scenario {scenario_id}")
-                metrics_list = self._run_mixed_workload(
-                    scenario,
-                    group_id,
-                    config_set,
-                    metrics_processor,
-                    warmup_duration,
-                    commit_time,
-                    group_description=group_description,
-                    scenario_id=scenario_id,
-                )
-                if profiler and scenario_profiling_enabled:
-                    profiler.stop_profiling(profile_id)
-                return metrics_list if metrics_list else None
+        cpu = self.client_cpu_ranges[0] if self.client_cpu_ranges else None
+        proc = self._run(
+            self._build_benchmark_command(
+                scenario=scenario, cpu_range=cpu, seed_val=seed_val
+            ),
+            cwd=self.valkey_path,
+            capture_output=True,
+            timeout=None,
+        )
+        return proc, None
 
-            if self._should_use_parallel(scenario):
-                logging.info(f"Using parallel execution for scenario {scenario_id}")
-                aggregated_row = self._run_parallel_search(
-                    scenario, self._get_active_ports(), self.client_cpu_ranges
-                )
-                proc = None
-            else:
-                cpu = self.client_cpu_ranges[0] if self.client_cpu_ranges else None
-                proc = self._run(
-                    self._build_benchmark_command(scenario=scenario, cpu_range=cpu),
-                    cwd=self.valkey_path,
-                    capture_output=True,
-                    timeout=None,
-                )
-                aggregated_row = None
+    def _build_scenario_metrics(
+        self,
+        scenario,
+        proc,
+        aggregated_row,
+        group_id,
+        config_set,
+        warmup_duration,
+        group_description,
+        metrics_processor,
+    ):
+        """Parse output and construct a metric row when one is available.
 
-            if profiler and scenario_profiling_enabled:
-                profiler.stop_profiling(profile_id)
+        Compiled basic scenarios retain the basic schema; other rows receive
+        scenario identity fields.
+        """
+        if not metrics_processor:
+            return None
 
-            if proc is None and aggregated_row is None:
-                logging.error(f"Benchmark failed for scenario {scenario_id}")
-                if metrics_processor:
-                    return self._create_failure_marker(
-                        group_id,
-                        scenario_id,
-                        scenario_type,
-                        "No results",
-                        scenario["command"],
-                        commit_time,
-                        config_set,
-                    )
-                return None
+        scenario_id = scenario.get("id", "unknown")
+        scenario_type = scenario.get("type", "test")
+        origin_simple = scenario.get(ORIGIN_FIELD) == ORIGIN_SIMPLE
 
-            if proc:
-                logging.info(f"Benchmark output:\n{proc.stdout}")
+        requests_value = scenario.get("requests") or scenario.get("maxdocs")
 
-            if metrics_processor:
-                requests_value = scenario.get("requests") or scenario.get("maxdocs")
-                row = aggregated_row or self._parse_csv_row(proc.stdout if proc else "")
+        if aggregated_row:
+            row = aggregated_row
+            command_label = (
+                scenario["command"]
+                if "command" in scenario
+                else row.get("test") or scenario["test"]
+            )
+        elif "test" in scenario:
+            row = self._parse_csv_row_for_test(
+                proc.stdout if proc else "", scenario["test"]
+            )
+            command_label = row.get("test") if row else None
+        else:
+            row = self._parse_csv_row(proc.stdout if proc else "")
+            command_label = scenario["command"]
 
-                if not row:
-                    logging.warning(f"No metrics data for scenario {scenario_id}")
-                    return None
+        if not row:
+            logging.warning(f"No metrics data for scenario {scenario_id}")
+            return None
 
-                metrics = metrics_processor.create_metrics(
-                    row,
-                    scenario["command"],
-                    scenario.get("data_size", 100),
-                    scenario.get("pipeline", 1),
-                    scenario.get("clients", 1),
-                    requests_value,
-                    warmup_duration,
-                    scenario.get("duration"),
-                )
+        warmup_metrics = (
+            scenario["warmup_inline"]
+            if "warmup_inline" in scenario
+            else warmup_duration
+        )
 
-                if metrics:
-                    metrics["status"] = "success"
-                    metrics["test_id"] = f"{group_id}_{scenario_id}"
-                    metrics["test_phase"] = scenario_type
-                    metrics["group"] = group_id
-                    metrics["scenario"] = scenario_id
-                    if group_description:
-                        metrics["group_description"] = group_description
-                    if scenario.get("description"):
-                        metrics["scenario_description"] = scenario["description"]
-                    metrics["config_set"] = config_set
-                    if self.config_name:
-                        metrics["config_name"] = self.config_name
-                    if self.module_commit:
-                        metrics["module_commit"] = self.module_commit
-                    if self.module_commit_timestamp:
-                        metrics["module_commit_timestamp"] = (
-                            self.module_commit_timestamp
-                        )
-                    if scenario.get("dataset"):
-                        metrics["dataset"] = scenario["dataset"]
-                    return metrics
+        metrics = metrics_processor.create_metrics(
+            row,
+            command_label,
+            scenario.get("data_size", 100),
+            scenario.get("pipeline", 1),
+            scenario.get("clients", 1),
+            requests_value,
+            warmup_metrics,
+            scenario.get("duration"),
+        )
 
-        except Exception as e:
-            logging.error(f"Scenario {group_id}_{scenario_id} failed: {e}")
-            if metrics_processor:
-                return self._create_failure_marker(
-                    group_id,
-                    scenario_id,
-                    scenario_type,
-                    str(e),
-                    scenario["command"],
-                    commit_time,
-                    config_set,
-                )
+        if not metrics:
+            return None
 
-        return None
+        if origin_simple:
+            logging.info(f"Parsed metrics for {command_label}: {metrics}")
+            return metrics
+
+        metrics["status"] = "success"
+        self._apply_row_metadata(
+            metrics,
+            test_id=f"{group_id}_{scenario_id}",
+            test_phase=scenario_type,
+            group_id=group_id,
+            scenario_id=scenario_id,
+            config_set=config_set,
+            group_description=group_description,
+            scenario_description=scenario.get("description"),
+            dataset=scenario.get("dataset"),
+        )
+        return metrics
 
     def _execute_setup_command(self, cmd_str: str) -> None:
         """Execute a setup command via valkey client."""
@@ -1093,19 +1106,23 @@ class ClientRunner:
             raise
 
     def _normalize_mixed_configs(self, scenario: dict):
-        """Propagate shared parameters from parent scenario to sub-scenarios.
-
-        Writes/reads sub-scenarios inherit ``duration``, ``pipeline``, and
-        ``cluster_execution`` from the parent when not explicitly set.
-        """
+        """Apply inherited parent parameters to mixed children."""
         write_scenarios = scenario.get("writes", [])
         read_scenarios = scenario.get("reads", [])
 
         for cfg in write_scenarios + read_scenarios:
+            # Inherit the parent's run bound / shape only where the sub omits it.
+            # duration-over-requests precedence stays in _build_benchmark_command.
             if "duration" not in cfg and scenario.get("duration") is not None:
                 cfg["duration"] = scenario["duration"]
+            if "requests" not in cfg and scenario.get("requests") is not None:
+                cfg["requests"] = scenario["requests"]
             if "pipeline" not in cfg:
                 cfg["pipeline"] = scenario.get("pipeline", 1)
+            # A parent data_size must reach subs, else _create_mixed_metric
+            # misreports the payload as its data_size=100 default.
+            if "data_size" not in cfg and scenario.get("data_size") is not None:
+                cfg["data_size"] = scenario["data_size"]
             if "cluster_execution" not in cfg and scenario.get("cluster_execution"):
                 cfg["cluster_execution"] = scenario["cluster_execution"]
 
@@ -1114,10 +1131,13 @@ class ClientRunner:
     def _get_cpu_for_mixed_process(self, process_idx: int) -> Optional[str]:
         """Allocate ``cores_per_client`` cores to each mixed-workload process.
 
-        Splits the client CPU pool starting from the first configured range so
-        each concurrent process runs on its own cores. Logs a warning if the
-        allocation would extend past the end of the last configured range so
-        the operator knows processes will start overlapping cores.
+        Cores inside the configured client pool are handed out by indexing the
+        flattened core list, so a non-contiguous pool like "10-11,20-21" gives
+        process 0 -> "10-11" and process 1 -> "20-21" (never the absent
+        "12-13"). Once the pool is exhausted the allocation continues
+        arithmetically past the last pool core and logs a warning, so an
+        undersized pool (e.g. the shipped FTS config) spills onto extra cores
+        rather than aborting the run.
         """
         if not self.client_cpu_ranges:
             return None
@@ -1125,28 +1145,32 @@ class ClientRunner:
         cpu_alloc = self.config.get("cpu_allocation", {})
         cores_per_client = cpu_alloc.get("cores_per_client", 1)
 
-        first_range = self.client_cpu_ranges[0]
-        if "-" in first_range:
-            start_core, _ = map(int, first_range.split("-"))
-        else:
-            start_core = int(first_range)
+        # Flatten the pool across every range string, in order. Indexing the
+        # real core list (not first..last arithmetic) keeps a non-contiguous
+        # pool like "10-11,20-21" from handing process 1 the absent cores 12-13.
+        pool = []
+        for range_str in self.client_cpu_ranges:
+            pool.extend(parse_core_range(range_str))
 
-        proc_start = start_core + (process_idx * cores_per_client)
+        # Processes that fit fully inside the pool get their real cores. A
+        # partial trailing slice counts as pool exhaustion for that process.
+        num_pool_processes = len(pool) // cores_per_client
+        if process_idx < num_pool_processes:
+            start = process_idx * cores_per_client
+            cores = pool[start : start + cores_per_client]
+            return format_core_list(cores)
+
+        # Pool exhausted: continue arithmetically past the last pool core and
+        # warn that processes may overlap CPU cores.
+        last_core = pool[-1]
+        spill_idx = process_idx - num_pool_processes
+        proc_start = last_core + 1 + (spill_idx * cores_per_client)
         proc_end = proc_start + cores_per_client - 1
-
-        # Warn if we've walked off the end of the last configured range.
-        last_range = self.client_cpu_ranges[-1]
-        if "-" in last_range:
-            _, end_core = map(int, last_range.split("-"))
-        else:
-            end_core = int(last_range)
-        if proc_end > end_core:
-            logging.warning(
-                f"Mixed process {process_idx} pinned to cores {proc_start}-{proc_end} "
-                f"which exceeds the client CPU pool ending at core {end_core}. "
-                f"Processes may overlap CPU cores."
-            )
-
+        logging.warning(
+            f"Mixed process {process_idx} pinned to cores {proc_start}-{proc_end} "
+            f"which exceeds the client CPU pool ending at core {last_core}. "
+            f"Processes may overlap CPU cores."
+        )
         return f"{proc_start}-{proc_end}" if proc_end > proc_start else str(proc_start)
 
     def _launch_mixed_process(
@@ -1173,28 +1197,56 @@ class ClientRunner:
         """Launch all mixed write + read processes across the given ports."""
         process_idx = 0
         write_procs = []
-        for write_cfg in write_scenarios:
-            sub = copy.deepcopy(write_cfg)
-            write_id = write_cfg.get("id", "w")
-            for port in ports:
-                proc = self._launch_mixed_process(
-                    sub, port, process_idx, f"write-{write_id}"
-                )
-                write_procs.append((proc, port, write_id))
-                process_idx += 1
-
         read_procs = []
-        for read_cfg in read_scenarios:
-            sub = copy.deepcopy(read_cfg)
-            read_id = read_cfg.get("id", "r")
-            for port in ports:
-                proc = self._launch_mixed_process(
-                    sub, port, process_idx, f"read-{read_id}"
-                )
-                read_procs.append((proc, port, read_id))
-                process_idx += 1
+        try:
+            for write_cfg in write_scenarios:
+                sub = copy.deepcopy(write_cfg)
+                write_id = write_cfg.get("id", "w")
+                for port in ports:
+                    proc = self._launch_mixed_process(
+                        sub, port, process_idx, f"write-{write_id}"
+                    )
+                    write_procs.append((proc, port, write_id))
+                    process_idx += 1
+
+            for read_cfg in read_scenarios:
+                sub = copy.deepcopy(read_cfg)
+                read_id = read_cfg.get("id", "r")
+                for port in ports:
+                    proc = self._launch_mixed_process(
+                        sub, port, process_idx, f"read-{read_id}"
+                    )
+                    read_procs.append((proc, port, read_id))
+                    process_idx += 1
+        except Exception:
+            self._terminate_mixed_processes(write_procs + read_procs)
+            raise
 
         return write_procs, read_procs
+
+    @staticmethod
+    def _terminate_mixed_processes(procs: List[tuple]) -> None:
+        """Stop every still-running mixed client and reap it."""
+        running = []
+        for proc, _port, _sub_id in procs:
+            try:
+                if proc.poll() is None:
+                    proc.terminate()
+                    running.append(proc)
+            except Exception:
+                logging.exception("Failed to terminate mixed benchmark process")
+
+        for proc in running:
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                try:
+                    proc.kill()
+                    proc.wait(timeout=5)
+                except Exception:
+                    logging.exception("Failed to kill mixed benchmark process")
+            except Exception:
+                logging.exception("Failed to reap mixed benchmark process")
 
     def _collect_mixed_results(self, procs: List[tuple], label: str) -> dict:
         """Wait for mixed workload processes and group results by sub-scenario id."""
@@ -1226,13 +1278,25 @@ class ClientRunner:
         if not metrics_processor:
             return None
 
+        # A sub-scenario carries EITHER an arbitrary ``command`` (recorded
+        # verbatim) or a predefined ``test`` workload. For a ``test:`` sub the
+        # command field records the CSV row's own test name, falling back to the
+        # sub's test name -- the same convention _build_scenario_metrics uses for
+        # a predefined workload's aggregated row (row["test"] is set to the
+        # canonical test name by _aggregate_parallel_results).
+        command_label = (
+            sub_cfg["command"]
+            if "command" in sub_cfg
+            else row.get("test") or sub_cfg["test"]
+        )
+
         metrics = metrics_processor.create_metrics(
             row,
-            sub_cfg["command"],
+            command_label,
             sub_cfg.get("data_size", 100),
             sub_cfg.get("pipeline", 1),
             sub_cfg.get("clients", 1),
-            None,
+            sub_cfg.get("requests") or parent_scenario.get("requests"),
             warmup_duration,
             sub_cfg.get("duration") or parent_scenario.get("duration"),
         )
@@ -1240,23 +1304,17 @@ class ClientRunner:
             return None
 
         metrics["status"] = "success"
-        metrics["test_id"] = f"{group_id}_{scenario_id}_{phase}_{sub_id}"
-        metrics["test_phase"] = f"mixed_{phase}"
-        metrics["group"] = group_id
-        metrics["scenario"] = scenario_id
-        metrics["config_set"] = config_set
-        if group_description:
-            metrics["group_description"] = group_description
-        if parent_scenario.get("description"):
-            metrics["scenario_description"] = parent_scenario["description"]
-        if self.config_name:
-            metrics["config_name"] = self.config_name
-        if self.module_commit:
-            metrics["module_commit"] = self.module_commit
-        if self.module_commit_timestamp:
-            metrics["module_commit_timestamp"] = self.module_commit_timestamp
-        if sub_cfg.get("dataset"):
-            metrics["dataset"] = sub_cfg["dataset"]
+        self._apply_row_metadata(
+            metrics,
+            test_id=f"{group_id}_{scenario_id}_{phase}_{sub_id}",
+            test_phase=f"mixed_{phase}",
+            group_id=group_id,
+            scenario_id=scenario_id,
+            config_set=config_set,
+            group_description=group_description,
+            scenario_description=parent_scenario.get("description"),
+            dataset=sub_cfg.get("dataset"),
+        )
         return metrics
 
     def _run_mixed_workload(
@@ -1266,15 +1324,12 @@ class ClientRunner:
         config_set: dict,
         metrics_processor,
         warmup_duration: int,
-        commit_time: str,
         group_description: Optional[str] = None,
-        scenario_id: Optional[str] = None,
     ) -> Optional[List[dict]]:
-        """Run a mixed workload of concurrent writes + reads.
+        """Run concurrent mixed children and return one row per expected child.
 
-        Each write and read sub-scenario is launched as its own process on the
-        appropriate ports and CPU range. Results are collected and reported as
-        one metric per sub-scenario id.
+        Missing results become child-specific failure rows. Warmups drain all
+        processes without recording rows and propagate launch failures.
         """
         write_scenarios, read_scenarios = self._normalize_mixed_configs(scenario)
 
@@ -1284,83 +1339,105 @@ class ClientRunner:
             )
             return None
 
-        # Determine target ports based on cluster execution mode
-        if scenario.get("cluster_execution") == "single" or not self._is_cme():
-            ports = [self._get_active_ports()[0]]
-        else:
-            ports = self._get_active_ports()
+        sid = scenario.get("id", "unknown")
+        warmup_mode = metrics_processor is None
+        write_procs: List[tuple] = []
+        read_procs: List[tuple] = []
 
-        # Each sub-scenario is launched once per port (i.e. once per node in
-        # CME parallel mode), so the real client count is `clients * len(ports)`
-        # per sub-scenario.
-        total_writes = sum(w.get("clients", 1) for w in write_scenarios) * len(ports)
-        total_reads = sum(r.get("clients", 1) for r in read_scenarios) * len(ports)
-        logging.info(
-            f"Mixed workload: {total_writes} write clients + {total_reads} read clients "
-            f"across {len(ports)} node(s)"
-        )
+        expected = [(w, "write", w.get("id", "w")) for w in write_scenarios] + [
+            (r, "read", r.get("id", "r")) for r in read_scenarios
+        ]
 
-        # Launch all processes concurrently
-        write_procs, read_procs = self._launch_mixed_processes(
-            write_scenarios, read_scenarios, ports
-        )
-
-        # Collect results grouped by sub-scenario id
-        write_results = self._collect_mixed_results(write_procs, "write")
-        read_results = self._collect_mixed_results(read_procs, "read")
-
-        # If metrics_processor is None (warmup mode), just drain and exit
-        if metrics_processor is None:
-            return None
-
-        sid = scenario_id or scenario.get("id", "unknown")
-        metrics_list: List[dict] = []
-
-        for write_cfg in write_scenarios:
-            wid = write_cfg.get("id", "w")
-            if wid not in write_results or not write_results[wid]:
-                continue
-            row = self._aggregate_parallel_results(
-                write_results[wid], {"command": write_cfg["command"]}
-            )
-            m = self._create_mixed_metric(
-                row,
-                write_cfg,
-                scenario,
-                group_id,
-                sid,
-                wid,
-                "write",
-                config_set,
-                warmup_duration,
+        def _marker(sub_cfg, phase, sub_id, error):
+            return self._create_failure_marker(
                 metrics_processor,
-                group_description,
+                sub_cfg,
+                group_id=group_id,
+                scenario_id=sid,
+                test_id=f"{group_id}_{sid}_{phase}_{sub_id}",
+                test_phase=f"mixed_{phase}",
+                error=error,
+                config_set=config_set,
+                requests=sub_cfg.get("requests") or scenario.get("requests"),
+                warmup=warmup_duration,
+                parent_scenario=scenario,
+                group_description=group_description,
             )
-            if m:
-                metrics_list.append(m)
 
-        for read_cfg in read_scenarios:
-            rid = read_cfg.get("id", "r")
-            if rid not in read_results or not read_results[rid]:
-                continue
-            row = self._aggregate_parallel_results(
-                read_results[rid], {"command": read_cfg["command"]}
+        try:
+            if scenario.get("cluster_execution") == "single" or not self._is_cme():
+                ports = [self._get_active_ports()[0]]
+            else:
+                ports = self._get_active_ports()
+
+            total_writes = sum(w.get("clients", 1) for w in write_scenarios) * len(
+                ports
             )
-            m = self._create_mixed_metric(
-                row,
-                read_cfg,
-                scenario,
-                group_id,
-                sid,
-                rid,
-                "read",
-                config_set,
-                warmup_duration,
-                metrics_processor,
-                group_description,
+            total_reads = sum(r.get("clients", 1) for r in read_scenarios) * len(ports)
+            logging.info(
+                f"Mixed workload: {total_writes} write clients + {total_reads} read clients "
+                f"across {len(ports)} node(s)"
             )
-            if m:
-                metrics_list.append(m)
+
+            write_procs, read_procs = self._launch_mixed_processes(
+                write_scenarios, read_scenarios, ports
+            )
+            write_results = self._collect_mixed_results(write_procs, "write")
+            read_results = self._collect_mixed_results(read_procs, "read")
+
+            if warmup_mode:
+                return None
+
+            metrics_list: List[dict] = []
+            for sub_cfg, phase, sub_id in expected:
+                results = write_results if phase == "write" else read_results
+                # A mixed sub-scenario carries EITHER ``command`` or ``test``;
+                # hand _aggregate_parallel_results the key it actually has so the
+                # aggregated row's test name is the workload the sub ran.
+                workload_key = "command" if "command" in sub_cfg else "test"
+                row = (
+                    self._aggregate_parallel_results(
+                        results[sub_id], {workload_key: sub_cfg[workload_key]}
+                    )
+                    if results.get(sub_id)
+                    else None
+                )
+                metric = (
+                    self._create_mixed_metric(
+                        row,
+                        sub_cfg,
+                        scenario,
+                        group_id,
+                        sid,
+                        sub_id,
+                        phase,
+                        config_set,
+                        warmup_duration,
+                        metrics_processor,
+                        group_description,
+                    )
+                    if row is not None
+                    else None
+                )
+                metrics_list.append(
+                    metric
+                    if metric is not None
+                    else _marker(
+                        sub_cfg,
+                        phase,
+                        sub_id,
+                        "Mixed sub-scenario produced no successful result",
+                    )
+                )
+        except Exception as e:
+            self._terminate_mixed_processes(write_procs + read_procs)
+            if warmup_mode:
+                raise
+            logging.error(f"Mixed workload for scenario {sid} raised: {e}")
+            metrics_list = [
+                _marker(sub_cfg, phase, sub_id, str(e))
+                for sub_cfg, phase, sub_id in expected
+            ]
 
         logging.info(f"Mixed workload produced {len(metrics_list)} metric entries")
         return metrics_list if metrics_list else None
@@ -1371,8 +1448,9 @@ class ClientRunner:
         ports: List[int],
         client_cpu_ranges: List[str],
         warmup_mode: bool = False,
+        seed_val: Optional[int] = None,
     ) -> dict:
-        """Run search benchmarks in parallel to all cluster nodes."""
+        """Run search on all cluster nodes, optionally sharing ``seed_val``."""
         # Check for custom parallel client count
         parallel_clients = scenario.get("parallel_clients")
         if parallel_clients:
@@ -1399,6 +1477,7 @@ class ClientRunner:
                 port=port,
                 cpu_range=cpu_range,
                 warmup_mode=warmup_mode,
+                seed_val=seed_val,
             )
             if warmup_mode:
                 logging.info(f"Launching warmup client {i} on port {port}")
@@ -1491,9 +1570,9 @@ class ClientRunner:
         min_latency = min(m["min_latency_ms"] for m in metrics_list)
         max_latency = max(m["max_latency_ms"] for m in metrics_list)
 
-        # Build aggregated result dict (CSV-like format)
+        workload_key = "command" if "command" in scenario else "test"
         aggregated = {
-            "test": scenario["command"],
+            "test": scenario[workload_key],
             "rps": str(total_rps),
             "avg_latency_ms": str(avg_latency),
             "min_latency_ms": str(min_latency),


### PR DESCRIPTION
`ClientRunner` had two execution trees picked by a `uses_test_groups` flag: one for the basic `commands` config format, one for scenario-based `test_groups`. Scheduling, server lifecycle, population, warmup, CSV parsing and metrics were written twice, so new features either got implemented twice or quietly worked in only one format. Profiling and `--runs` were scenario-only; arbitrary commands were impossible in the basic format.

This merges them. The basic format is compiled into generated `test_groups` at config load and the runner only walks the scenario path. Both formats stay supported and neither changes on the surface, so existing configs and the workflows that edit them keep working.

Scenarios pick up what the basic path used to own privately: `test` for predefined `-t` workloads, plus `data_size`, per-scenario `keyspacelen`, `warmup_inline`, `restart_before` and `populate_with`. `restart_before` and `flush_before` collapsed into one mechanism that also re-applies `config_set` after the restart, which the basic path had been dropping.

## Arbitrary commands

Scenarios using `command` now get the same client settings as predefined ones, which is what makes their numbers comparable: `data_size` reaches `-d`, so `__data__` is the size you asked for rather than valkey-benchmark's 3-byte default, and `benchmark-threads` reaches `--threads`, so the client isn't left single-threaded driving a thousand connections. `populate_with` works for them too.

## Fixes found along the way

Population ran outside the scenario error handler, so a failed populate escaped with no failure marker and silently skipped every later scenario. A `populate_with` that can't run is now rejected at validation instead of being skipped, which used to benchmark reads against an empty keyspace and report the result as if it meant something.

Parallel and mixed execution assumed every scenario had a `command`, so a predefined workload raised `KeyError` or silently produced no metrics. Mixed sub-scenarios also reported a hardcoded `data_size` of 100 regardless of payload. Parallel readers each drew their own seed instead of sharing the populate pass's, so they could read keys that were never written. Profiling cleanup only ran on success paths, so an exception left `perf` running.

Mixed sub-scenarios inherited a duration but not a request count, so a request-bounded mixed run either failed outright for predefined workloads or silently fell back to a 60 second default for arbitrary ones. The count now reaches the sub-scenarios and appears in their metrics rows and failure markers.

Mixed workloads now emit a failure marker per expected sub-scenario, covering partial failure (which previously reported nothing at all), total failure, and a mid-run exception, and orphaned client processes are terminated.

CPU pinning for mixed processes indexes the real core list, so a non-contiguous client pool such as `10-11,20-21` no longer hands a process the absent cores in the gap. Allocation past the end of the pool keeps its existing warn-and-continue behaviour.

## Comparison tool

Several bugs shared one cause: fields that are metadata, not configuration, leaked into the signature used to pair baseline rows with new rows.

`env_`-prefixed metadata is excluded now. This one was live on main: the CPU frequency is read at runtime, so two runs on the same host produced different signatures and the comparison table came out empty. Only genuinely volatile readings are excluded, so two different machines no longer compare as though the software changed.

Signatures are discovered across both datasets, and a `config_set` sweep participates, where distinct server configurations used to be averaged together as repeated runs, quietly turning 100 and 200 into 150. The sweep value now appears in group headings so the tables are attributable.

Failure markers carry the full scenario identity. Without it a failure never paired with its own successful counterpart, so you got a fabricated `-100%` next to an orphan row. Failed scenarios are excluded from the numeric comparison, since they have no metrics, and reported in a table keyed on that identity.

## utils/modify_config.py

Consumer repos build a config by editing one with jq inside their workflow: bounds-checking inputs, deriving `server_cpu_range`, and for arbitrary commands assembling a whole `test_groups` block. That's schema knowledge living outside the repo that owns the schema, it can't be tested there, and every consumer reimplements it.

The script does the same work and validates the result through `validate_config` before writing, so it can't emit a config the runner would reject. Where an input is ambiguous it is rejected rather than quietly resolved: a base carrying both `duration` and `requests`, a single-value field given a list, a command whose name is empty, a client pool too small for the processes a mixed load will start. Validation covers every entry in the file, and CPU range checks read the effective allocation, so the conversion that folds explicit ranges into `cpu_allocation` cannot hide a server and client overlap. It has three modes: predefined commands, one arbitrary command with optional population, and a concurrent read plus write mix. The mixed mode splits the configured client count by a ratio so total load is unchanged, derives the CPU allocation the concurrent processes need, pins the generated scenario to single-node execution so the process count stays fixed rather than multiplying per cluster node, warms with writes only so the warmup budget populates instead of reading a cold keyspace, and takes either a predefined workload or an arbitrary command string on each side. Runner-specific bounds are parameters rather than constants.

It removes about 160 lines from the valkey workflow that calls it.

## Behaviour changes worth calling out

- Compiled basic-format scenarios re-apply `config_set` after restart; those values used to be lost.
- `--groups` and `--scenarios` now filter basic configs; they were accepted and ignored before.
- Comparison output changes as described above.
- Basic-format `metrics.json` field set is unchanged.

## Testing

Parity is pinned by exact-argv tests asserting complete command lines for a compiled write workload, a compiled read workload including its populate pass, and an arbitrary command, plus an integration test covering load, compile and a mocked run.

One lesson is baked in: several of these bugs hid because tests hand-built rows in shapes production never emits, and because comparison tests called `create_comparison_table_data` directly and skipped the averaging stage `main()` runs. Rows are now built by the real producers, and the comparison tests go through averaging.

Full suite: 779 passed, 23 skipped.

