### PR TITLE
fix: wait for port to be free after SIGKILL before restarting

### DIFF
--- a/tests/test_shutdown_logic.py
+++ b/tests/test_shutdown_logic.py
@@ -90,6 +90,63 @@ class TestGetValkeyPids:
         assert launcher._get_valkey_pids() == []
 
 
+class TestWaitForPortAvailable:
+    """Test _wait_for_port_available helper."""
+
+    @patch("valkey_server.subprocess.run")
+    def test_returns_immediately_when_port_free(self, mock_run, launcher):
+        """Port is free (no output lines) — should return quickly."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="State  Recv-Q Send-Q Local Address:Port\n"
+        )
+        start = time.time()
+        launcher._wait_for_port_available(port=6379, timeout=10)
+        elapsed = time.time() - start
+        assert (
+            elapsed < 2.0
+        ), f"Should return immediately when port free, took {elapsed:.1f}s"
+
+    @patch("valkey_server.subprocess.run")
+    def test_waits_until_port_free(self, mock_run, launcher):
+        """Port is busy first, then becomes free after 2 calls."""
+        busy_result = MagicMock(
+            returncode=0,
+            stdout="State  Recv-Q Send-Q Local Address:Port\nLISTEN 0      511    *:6379\n",
+        )
+        free_result = MagicMock(
+            returncode=0, stdout="State  Recv-Q Send-Q Local Address:Port\n"
+        )
+        mock_run.side_effect = [busy_result, busy_result, free_result]
+
+        start = time.time()
+        launcher._wait_for_port_available(port=6379, timeout=10)
+        elapsed = time.time() - start
+        # Should take ~2s (2 sleep(1) iterations before free)
+        assert 1.5 < elapsed < 4.0, f"Expected ~2s wait, got {elapsed:.1f}s"
+
+    @patch("valkey_server.subprocess.run")
+    def test_proceeds_after_timeout(self, mock_run, launcher):
+        """Port never frees — should warn and proceed after timeout."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="State  Recv-Q Send-Q Local Address:Port\nLISTEN 0      511    *:6379\n",
+        )
+        start = time.time()
+        # Use short timeout so test doesn't take long
+        launcher._wait_for_port_available(port=6379, timeout=3)
+        elapsed = time.time() - start
+        assert 2.5 < elapsed < 5.0, f"Should wait ~3s then proceed, took {elapsed:.1f}s"
+
+    @patch("valkey_server.subprocess.run")
+    def test_handles_ss_failure(self, mock_run, launcher):
+        """If ss command fails, should still proceed after timeout."""
+        mock_run.side_effect = Exception("ss not found")
+        start = time.time()
+        launcher._wait_for_port_available(port=6379, timeout=3)
+        elapsed = time.time() - start
+        assert 2.5 < elapsed < 5.0, f"Should wait ~3s then proceed, took {elapsed:.1f}s"
+
+
 # ---------------------------------------------------------------------------
 # Real-process test: validates shutdown + SIGKILL escalation
 # ---------------------------------------------------------------------------

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -1058,9 +1058,9 @@ class ClientRunner:
                     if self.module_commit:
                         metrics["module_commit"] = self.module_commit
                     if self.module_commit_timestamp:
-                        metrics[
-                            "module_commit_timestamp"
-                        ] = self.module_commit_timestamp
+                        metrics["module_commit_timestamp"] = (
+                            self.module_commit_timestamp
+                        )
                     if scenario.get("dataset"):
                         metrics["dataset"] = scenario["dataset"]
                     return metrics

--- a/valkey_benchmark.py
+++ b/valkey_benchmark.py
@@ -1058,9 +1058,9 @@ class ClientRunner:
                     if self.module_commit:
                         metrics["module_commit"] = self.module_commit
                     if self.module_commit_timestamp:
-                        metrics["module_commit_timestamp"] = (
-                            self.module_commit_timestamp
-                        )
+                        metrics[
+                            "module_commit_timestamp"
+                        ] = self.module_commit_timestamp
                     if scenario.get("dataset"):
                         metrics["dataset"] = scenario["dataset"]
                     return metrics

--- a/valkey_server.py
+++ b/valkey_server.py
@@ -254,6 +254,40 @@ class ServerLauncher:
 
         return cmd
 
+    def _wait_for_port_available(
+        self, port: int = DEFAULT_PORT, timeout: int = 60
+    ) -> None:
+        """Wait until the TCP port is free (not in TIME_WAIT/LISTEN).
+
+        After SIGKILL, the kernel may hold the socket in TIME_WAIT for up to 60s.
+        This method blocks until the port is available for binding.
+        """
+        logging.info(f"Waiting for port {port} to become available...")
+        start = time.time()
+        while time.time() - start < timeout:
+            try:
+                result = subprocess.run(
+                    ["ss", "-tlnp", f"sport = :{port}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                # If no lines with the port in LISTEN state, port is free
+                lines = [l for l in result.stdout.strip().split("\n")[1:] if l.strip()]
+                if not lines:
+                    elapsed = time.time() - start
+                    if elapsed > 1:
+                        logging.info(f"Port {port} available after {elapsed:.1f}s")
+                    return
+            except Exception as e:
+                logging.warning(f"Error checking port availability: {e}")
+            time.sleep(1)
+
+        logging.warning(
+            f"Port {port} still not available after {timeout}s. "
+            f"Proceeding anyway (server may fail to bind)."
+        )
+
     def _wait_for_server_ready(
         self, tls_mode: bool, timeout: int = DEFAULT_TIMEOUT
     ) -> None:
@@ -662,6 +696,8 @@ class ServerLauncher:
         while time.time() < kill_deadline:
             if not self._valkey_processes_running():
                 logging.info("Valkey server terminated after SIGKILL.")
+                # After SIGKILL, port may be in TIME_WAIT - wait for it
+                self._wait_for_port_available()
                 return
             time.sleep(0.5)
 


### PR DESCRIPTION
After SIGKILL the port stays in TIME_WAIT for up to 60s. The new server fails with 'Address already in use'. Added _wait_for_port_available() that polls ss -tlnp for up to 60s until the port is free.

Includes unit tests for the new helper.